### PR TITLE
Synchronize Astro components with core UI recipes and types

### DIFF
--- a/dist/components/SpBadge.astro
+++ b/dist/components/SpBadge.astro
@@ -1,27 +1,11 @@
 ---
-import type { BadgeSize, BadgeVariant } from "@phcdevworks/spectre-ui";
+import type { BadgeRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getBadgeClasses } from "@phcdevworks/spectre-ui";
 
-interface SpBadgeProps {
-  variant?: BadgeVariant;
-  size?: BadgeSize;
+interface SpBadgeProps extends BadgeRecipeOptions {
   class?: string;
   [key: string]: any;
 }
-
-const badgeVariants: BadgeVariant[] = [
-  "primary",
-  "success",
-  "warning",
-  "danger",
-];
-const badgeSizes: BadgeSize[] = ["sm", "md", "lg"];
-
-const isBadgeVariant = (value: unknown): value is BadgeVariant =>
-  typeof value === "string" && badgeVariants.includes(value as BadgeVariant);
-
-const isBadgeSize = (value: unknown): value is BadgeSize =>
-  typeof value === "string" && badgeSizes.includes(value as BadgeSize);
 
 const {
   variant,
@@ -30,16 +14,9 @@ const {
   ...attrs
 } = Astro.props as SpBadgeProps;
 
-const resolvedVariant: BadgeVariant = isBadgeVariant(variant)
-  ? variant
-  : "primary";
-const resolvedSize: BadgeSize | undefined = isBadgeSize(size)
-  ? size
-  : undefined;
-
 const classes = getBadgeClasses({
-  variant: resolvedVariant,
-  size: resolvedSize,
+  variant,
+  size,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 

--- a/dist/components/SpButton.astro
+++ b/dist/components/SpButton.astro
@@ -1,17 +1,11 @@
 ---
-import type { ButtonSize, ButtonVariant } from "@phcdevworks/spectre-ui";
+import type { ButtonRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getButtonClasses } from "@phcdevworks/spectre-ui";
 
 type SpButtonElement = "button" | "a" | "span";
 
-interface SpButtonProps {
+interface SpButtonProps extends ButtonRecipeOptions {
   as?: SpButtonElement;
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  fullWidth?: boolean;
-  loading?: boolean;
-  disabled?: boolean;
-  iconOnly?: boolean;
   class?: string;
 
   href?: string;
@@ -24,12 +18,12 @@ interface SpButtonProps {
 
 const {
   as = "button",
-  variant = "primary",
-  size = "md",
-  fullWidth = false,
-  loading = false,
-  disabled = false,
-  iconOnly = false,
+  variant,
+  size,
+  fullWidth,
+  loading,
+  disabled,
+  iconOnly,
   class: className,
   ...rest
 } = Astro.props as SpButtonProps;

--- a/dist/components/SpCard.astro
+++ b/dist/components/SpCard.astro
@@ -1,22 +1,18 @@
 ---
-import type { CardVariant } from "@phcdevworks/spectre-ui";
+import type { CardRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getCardClasses } from "@phcdevworks/spectre-ui";
 
-interface SpCardProps {
-  variant?: CardVariant;
-  interactive?: boolean;
-  padded?: boolean;
-  fullHeight?: boolean;
+interface SpCardProps extends CardRecipeOptions {
   as?: "div" | "section" | "article";
   class?: string;
   [key: string]: any;
 }
 
 const {
-  variant = "elevated",
-  interactive = false,
-  padded = true,
-  fullHeight = false,
+  variant,
+  interactive,
+  padded,
+  fullHeight,
   as = "div",
   class: className,
   ...rest

--- a/dist/components/SpIconBox.astro
+++ b/dist/components/SpIconBox.astro
@@ -1,10 +1,8 @@
 ---
-import type { IconBoxSize, IconBoxVariant } from "@phcdevworks/spectre-ui";
+import type { IconBoxRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
 
-interface SpIconBoxProps {
-  variant?: IconBoxVariant;
-  size?: IconBoxSize;
+interface SpIconBoxProps extends IconBoxRecipeOptions {
   as?: "div" | "span";
   class?: string;
   [key: string]: any;

--- a/dist/components/SpInput.astro
+++ b/dist/components/SpInput.astro
@@ -1,12 +1,9 @@
 ---
-import type { InputSize, InputState } from "@phcdevworks/spectre-ui";
+import type { InputRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getInputClasses } from "@phcdevworks/spectre-ui";
 
-interface SpInputProps {
+interface SpInputProps extends InputRecipeOptions {
   label?: string;
-  state?: InputState;
-  size?: InputSize;
-  fullWidth?: boolean;
   helperText?: string;
   errorMessage?: string;
   id?: string;
@@ -16,9 +13,9 @@ interface SpInputProps {
 
 const {
   label,
-  state = "default",
-  size = "md",
-  fullWidth = false,
+  state,
+  size,
+  fullWidth,
   helperText,
   errorMessage,
   id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@phcdevworks/spectre-ui": "git+https://github.com/phcdevworks/spectre-ui.git#main"
+        "@phcdevworks/spectre-ui": "github:phcdevworks/spectre-ui#main"
       },
       "devDependencies": {
         "@types/chroma-js": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "astro": "^5.0.0"
   },
   "dependencies": {
-    "@phcdevworks/spectre-ui": "git+https://github.com/phcdevworks/spectre-ui.git#main"
+    "@phcdevworks/spectre-ui": "github:phcdevworks/spectre-ui#main"
   },
   "devDependencies": {
     "@types/chroma-js": "^3.1.2",

--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -1,27 +1,11 @@
 ---
-import type { BadgeSize, BadgeVariant } from "@phcdevworks/spectre-ui";
+import type { BadgeRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getBadgeClasses } from "@phcdevworks/spectre-ui";
 
-interface SpBadgeProps {
-  variant?: BadgeVariant;
-  size?: BadgeSize;
+interface SpBadgeProps extends BadgeRecipeOptions {
   class?: string;
   [key: string]: any;
 }
-
-const badgeVariants: BadgeVariant[] = [
-  "primary",
-  "success",
-  "warning",
-  "danger",
-];
-const badgeSizes: BadgeSize[] = ["sm", "md", "lg"];
-
-const isBadgeVariant = (value: unknown): value is BadgeVariant =>
-  typeof value === "string" && badgeVariants.includes(value as BadgeVariant);
-
-const isBadgeSize = (value: unknown): value is BadgeSize =>
-  typeof value === "string" && badgeSizes.includes(value as BadgeSize);
 
 const {
   variant,
@@ -30,16 +14,9 @@ const {
   ...attrs
 } = Astro.props as SpBadgeProps;
 
-const resolvedVariant: BadgeVariant = isBadgeVariant(variant)
-  ? variant
-  : "primary";
-const resolvedSize: BadgeSize | undefined = isBadgeSize(size)
-  ? size
-  : undefined;
-
 const classes = getBadgeClasses({
-  variant: resolvedVariant,
-  size: resolvedSize,
+  variant,
+  size,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 

--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -1,17 +1,11 @@
 ---
-import type { ButtonSize, ButtonVariant } from "@phcdevworks/spectre-ui";
+import type { ButtonRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getButtonClasses } from "@phcdevworks/spectre-ui";
 
 type SpButtonElement = "button" | "a" | "span";
 
-interface SpButtonProps {
+interface SpButtonProps extends ButtonRecipeOptions {
   as?: SpButtonElement;
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  fullWidth?: boolean;
-  loading?: boolean;
-  disabled?: boolean;
-  iconOnly?: boolean;
   class?: string;
 
   href?: string;
@@ -24,12 +18,12 @@ interface SpButtonProps {
 
 const {
   as = "button",
-  variant = "primary",
-  size = "md",
-  fullWidth = false,
-  loading = false,
-  disabled = false,
-  iconOnly = false,
+  variant,
+  size,
+  fullWidth,
+  loading,
+  disabled,
+  iconOnly,
   class: className,
   ...rest
 } = Astro.props as SpButtonProps;

--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -1,22 +1,18 @@
 ---
-import type { CardVariant } from "@phcdevworks/spectre-ui";
+import type { CardRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getCardClasses } from "@phcdevworks/spectre-ui";
 
-interface SpCardProps {
-  variant?: CardVariant;
-  interactive?: boolean;
-  padded?: boolean;
-  fullHeight?: boolean;
+interface SpCardProps extends CardRecipeOptions {
   as?: "div" | "section" | "article";
   class?: string;
   [key: string]: any;
 }
 
 const {
-  variant = "elevated",
-  interactive = false,
-  padded = true,
-  fullHeight = false,
+  variant,
+  interactive,
+  padded,
+  fullHeight,
   as = "div",
   class: className,
   ...rest

--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -1,10 +1,8 @@
 ---
-import type { IconBoxSize, IconBoxVariant } from "@phcdevworks/spectre-ui";
+import type { IconBoxRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
 
-interface SpIconBoxProps {
-  variant?: IconBoxVariant;
-  size?: IconBoxSize;
+interface SpIconBoxProps extends IconBoxRecipeOptions {
   as?: "div" | "span";
   class?: string;
   [key: string]: any;

--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -1,12 +1,9 @@
 ---
-import type { InputSize, InputState } from "@phcdevworks/spectre-ui";
+import type { InputRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getInputClasses } from "@phcdevworks/spectre-ui";
 
-interface SpInputProps {
+interface SpInputProps extends InputRecipeOptions {
   label?: string;
-  state?: InputState;
-  size?: InputSize;
-  fullWidth?: boolean;
   helperText?: string;
   errorMessage?: string;
   id?: string;
@@ -16,9 +13,9 @@ interface SpInputProps {
 
 const {
   label,
-  state = "default",
-  size = "md",
-  fullWidth = false,
+  state,
+  size,
+  fullWidth,
   helperText,
   errorMessage,
   id,


### PR DESCRIPTION
This change synchronizes all Astro components in @phcdevworks/spectre-ui-astro with the latest recipes and types from @phcdevworks/spectre-ui. 

Key changes include:
- Refactoring SpBadge, SpButton, SpCard, SpIconBox, and SpInput to extend their respective RecipeOptions interfaces from the core library.
- Removing hardcoded variant/size arrays and manual validation logic, delegating these to the UI package.
- Directly mapping component props to the corresponding recipe functions (e.g., getBadgeClasses, getButtonClasses).
- Aligning default values with the core recipes to ensure a single source of truth.
- Updating the dependency to the latest main branch of the UI repository.

Verified that the build and TypeScript compilation (tsc) pass without errors.

---
*PR created automatically by Jules for task [3030408110906149523](https://jules.google.com/task/3030408110906149523) started by @bradpotts*