### PR TITLE
Add polymorphic 'as' prop support to SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -2,7 +2,10 @@
 import type { BadgeRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getBadgeClasses } from "@phcdevworks/spectre-ui";
 
+type SpBadgeElement = "span" | "div";
+
 interface SpBadgeProps extends BadgeRecipeOptions {
+  as?: SpBadgeElement;
   class?: string;
   [key: string]: any;
 }
@@ -10,6 +13,7 @@ interface SpBadgeProps extends BadgeRecipeOptions {
 const {
   variant,
   size,
+  as: Tag = "span",
   class: className,
   ...attrs
 } = Astro.props as SpBadgeProps;
@@ -19,10 +23,8 @@ const classes = getBadgeClasses({
   size,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
-
-delete (attrs as any).class;
 ---
 
-<span class={finalClass} {...attrs}>
+<Tag class={finalClass} {...attrs}>
   <slot />
-</span>
+</Tag>


### PR DESCRIPTION
This change adds a polymorphic `as` prop to the `SpBadge` component, allowing it to be rendered as either a `span` (default) or a `div` element. This improvement increases the component's flexibility without introducing new CSS or business logic, adhering to the project's architectural guidelines for Layer 3. The implementation uses a dynamic tag pattern in the Astro template for concise and maintainable code.

---
*PR created automatically by Jules for task [3278909406341819244](https://jules.google.com/task/3278909406341819244) started by @bradpotts*