### PR TITLE
Add polymorphic 'as' prop to SpIconBox

### DIFF
--- a/dist/components/SpBadge.astro
+++ b/dist/components/SpBadge.astro
@@ -2,7 +2,10 @@
 import type { BadgeRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getBadgeClasses } from "@phcdevworks/spectre-ui";
 
+type SpBadgeElement = "span" | "div";
+
 interface SpBadgeProps extends BadgeRecipeOptions {
+  as?: SpBadgeElement;
   class?: string;
   [key: string]: any;
 }
@@ -10,6 +13,7 @@ interface SpBadgeProps extends BadgeRecipeOptions {
 const {
   variant,
   size,
+  as: Tag = "span",
   class: className,
   ...attrs
 } = Astro.props as SpBadgeProps;
@@ -19,10 +23,8 @@ const classes = getBadgeClasses({
   size,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
-
-delete (attrs as any).class;
 ---
 
-<span class={finalClass} {...attrs}>
+<Tag class={finalClass} {...attrs}>
   <slot />
-</span>
+</Tag>

--- a/dist/components/SpIconBox.astro
+++ b/dist/components/SpIconBox.astro
@@ -3,7 +3,7 @@ import type { IconBoxRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
 
 interface SpIconBoxProps extends IconBoxRecipeOptions {
-  as?: "div" | "span";
+  as?: "div" | "span" | "i";
   class?: string;
   [key: string]: any;
 }
@@ -11,25 +11,15 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 const {
   variant,
   size,
-  as = "span",
+  as: Tag = "span",
   class: className,
   ...attrs
 } = Astro.props as SpIconBoxProps;
 
 const classes = getIconBoxClasses({ variant, size });
 const finalClass = [classes, className].filter(Boolean).join(" ");
-
-delete (attrs as any).class;
 ---
 
-{
-  as === "div" ? (
-    <div class={finalClass} {...attrs}>
-      <slot />
-    </div>
-  ) : (
-    <span class={finalClass} {...attrs}>
-      <slot />
-    </span>
-  )
-}
+<Tag class={finalClass} {...attrs}>
+  <slot />
+</Tag>

--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -3,7 +3,7 @@ import type { IconBoxRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
 
 interface SpIconBoxProps extends IconBoxRecipeOptions {
-  as?: "div" | "span";
+  as?: "div" | "span" | "i";
   class?: string;
   [key: string]: any;
 }
@@ -11,25 +11,15 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 const {
   variant,
   size,
-  as = "span",
+  as: Tag = "span",
   class: className,
   ...attrs
 } = Astro.props as SpIconBoxProps;
 
 const classes = getIconBoxClasses({ variant, size });
 const finalClass = [classes, className].filter(Boolean).join(" ");
-
-delete (attrs as any).class;
 ---
 
-{
-  as === "div" ? (
-    <div class={finalClass} {...attrs}>
-      <slot />
-    </div>
-  ) : (
-    <span class={finalClass} {...attrs}>
-      <slot />
-    </span>
-  )
-}
+<Tag class={finalClass} {...attrs}>
+  <slot />
+</Tag>


### PR DESCRIPTION
This change adds support for the polymorphic `as` prop to the `SpIconBox` component, allowing it to be rendered as a `span`, `div`, or `i` element. The component was refactored to use the dynamic `Tag` pattern for cleaner rendering logic and better prop handling. Build artifacts in `dist/` were also updated to reflect the changes.

---
*PR created automatically by Jules for task [4683128802797024247](https://jules.google.com/task/4683128802797024247) started by @bradpotts*