### PR TITLE
Improve SpCard polymorphism and type safety

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -1,10 +1,29 @@
 ---
-import type { CardRecipeOptions } from "@phcdevworks/spectre-ui";
-import { getCardClasses } from "@phcdevworks/spectre-ui";
+import { getCardClasses, type CardRecipeOptions } from "@phcdevworks/spectre-ui";
+
+type SpCardElement =
+  | "div"
+  | "section"
+  | "article"
+  | "aside"
+  | "header"
+  | "footer"
+  | "main"
+  | "nav"
+  | "a"
+  | "button"
+  | "li";
 
 interface SpCardProps extends CardRecipeOptions {
-  as?: "div" | "section" | "article";
+  as?: SpCardElement;
   class?: string;
+
+  href?: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+
+  type?: "button" | "submit" | "reset";
+
   [key: string]: any;
 }
 
@@ -22,6 +41,10 @@ const classes = getCardClasses({ variant, interactive, padded, fullHeight });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 ---
 
-<Tag class={finalClass} {...rest}>
+<Tag
+  class={finalClass}
+  type={Tag === "button" ? (rest.type ?? "button") : undefined}
+  {...rest}
+>
   <slot />
 </Tag>


### PR DESCRIPTION
This submission enhances the `SpCard` component by expanding its polymorphism and improving type safety.

Key improvements:
- **Expanded Polymorphism:** The `as` prop now supports more semantic HTML tags: `aside`, `header`, `footer`, `main`, `nav`, `a`, `button`, and `li`.
- **Improved Type Safety:** `SpCardProps` now explicitly includes common attributes like `href`, `target`, `rel`, and `type`, providing better developer experience through IntelliSense.
- **Robust Button Handling:** Implemented a default `type="button"` for cards rendered as buttons to prevent common form submission issues.
- **Attribute Pass-through:** Used the spread operator `{...rest}` to ensure all standard HTML attributes are correctly passed to the underlying element.

The change is isolated to `src/components/SpCard.astro` and contains zero CSS, adhering to the project's architectural guardrails. All build checks passed successfully.

---
*PR created automatically by Jules for task [16932469994922882790](https://jules.google.com/task/16932469994922882790) started by @bradpotts*