### PR TITLE
Expand SpIconBox Polymorphism and Attribute Support

### DIFF
--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -2,9 +2,18 @@
 import type { IconBoxRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
 
+type SpIconBoxElement = "div" | "span" | "i" | "a" | "button" | "li";
+
 interface SpIconBoxProps extends IconBoxRecipeOptions {
-  as?: "div" | "span" | "i";
+  as?: SpIconBoxElement;
   class?: string;
+
+  href?: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+
+  type?: "button" | "submit" | "reset";
+
   [key: string]: any;
 }
 
@@ -13,13 +22,26 @@ const {
   size,
   as: Tag = "span",
   class: className,
+  href,
+  target,
+  rel,
+  type,
   ...attrs
 } = Astro.props as SpIconBoxProps;
 
 const classes = getIconBoxClasses({ variant, size });
 const finalClass = [classes, className].filter(Boolean).join(" ");
+
+const finalType = Tag === "button" ? (type ?? "button") : undefined;
 ---
 
-<Tag class={finalClass} {...attrs}>
+<Tag
+  class={finalClass}
+  href={Tag === "a" ? href : undefined}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
+  {...attrs}
+>
   <slot />
 </Tag>


### PR DESCRIPTION
I have improved the `SpIconBox` component by expanding its polymorphic support. It now supports being rendered as `<a>`, `<button>`, and `<li>` elements, in addition to the existing `<div>`, `<span>`, and `<i>` elements. I also added proper handling for element-specific attributes like `href` and `type` to ensure HTML validity and better accessibility. I verified the changes by building the project and checking the rendered output in the examples.

---
*PR created automatically by Jules for task [4668414125213633575](https://jules.google.com/task/4668414125213633575) started by @bradpotts*