### PR TITLE
Improve SpBadge polymorphism and fix variable shadowing

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -37,9 +37,16 @@ const classes = getBadgeClasses({
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
-const type = Tag === "button" ? (rest.type ?? "button") : undefined;
+const finalType = Tag === "button" ? (type ?? "button") : undefined;
 ---
 
-<Tag class={finalClass} type={type} {...rest}>
+<Tag
+  class={finalClass}
+  href={Tag === "a" ? href : undefined}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
+  {...rest}
+>
   <slot />
 </Tag>


### PR DESCRIPTION
I have improved the `SpBadge.astro` component by addressing a variable shadowing issue with the `type` attribute and adding proper support for polymorphism when rendering as an anchor (`<a>`) or button (`<button>`) tag. 

Previously, `href`, `target`, and `rel` were being destructured but not explicitly applied to the template, and they would be lost if passed in `...rest` due to how Astro handles prop spreading for certain attributes. By explicitly destructuring and then conditionally applying them based on the `Tag`, I've ensured they are correctly rendered only when valid for the underlying HTML element. 

I also fixed the shadowing of the `type` prop by using a `finalType` constant for the derived value. 

I verified the changes by running `npm run build` and by creating a temporary test page in the `examples/` project, which I verified using a Playwright script to ensure the correct attributes were being rendered in the DOM. I have restored all changes to the `examples/` directory to maintain a clean blast radius of exactly one `.astro` file.

---
*PR created automatically by Jules for task [14076640630882270131](https://jules.google.com/task/14076640630882270131) started by @bradpotts*