### PR TITLE
Improve SpCard attribute guarding and add form support

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -10,6 +10,7 @@ type SpCardElement =
   | "footer"
   | "main"
   | "nav"
+  | "form"
   | "a"
   | "button"
   | "li";
@@ -34,15 +35,26 @@ const {
   fullHeight,
   as: Tag = "div",
   class: className,
+  href,
+  target,
+  rel,
+  type,
   ...rest
 } = Astro.props as SpCardProps;
 
 const classes = getCardClasses({ variant, interactive, padded, fullHeight });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
-const type = Tag === "button" ? (rest.type ?? "button") : undefined;
+const finalType = Tag === "button" ? (type ?? "button") : undefined;
 ---
 
-<Tag class={finalClass} type={type} {...rest}>
+<Tag
+  class={finalClass}
+  href={Tag === "a" ? href : undefined}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
+  {...rest}
+>
   <slot />
 </Tag>


### PR DESCRIPTION
Modified `src/components/SpCard.astro` to add support for rendering as a `<form>` element and implemented strict attribute guarding. This ensures that element-specific attributes like `href`, `target`, `rel`, and `type` are only applied to their respective HTML tags (`<a>` and `<button>`), preventing invalid HTML attributes from being rendered on other container types. The change also prevents prop duplication and ensures consistent behavior across polymorphic components in the library.

---
*PR created automatically by Jules for task [6194372585159315654](https://jules.google.com/task/6194372585159315654) started by @bradpotts*