### PR TITLE
Expand SpButton polymorphism and add attribute guarding

### DIFF
--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -2,7 +2,7 @@
 import type { ButtonRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getButtonClasses } from "@phcdevworks/spectre-ui";
 
-type SpButtonElement = "button" | "a" | "span";
+type SpButtonElement = "button" | "a" | "span" | "div" | "li";
 
 interface SpButtonProps extends ButtonRecipeOptions {
   as?: SpButtonElement;
@@ -13,6 +13,7 @@ interface SpButtonProps extends ButtonRecipeOptions {
   rel?: string;
 
   type?: "button" | "submit" | "reset";
+  tabindex?: number;
   [key: string]: any;
 }
 
@@ -26,6 +27,11 @@ const {
   pill,
   as: Tag = "button",
   class: className,
+  href,
+  target,
+  rel,
+  type,
+  tabindex,
   ...rest
 } = Astro.props as SpButtonProps;
 
@@ -43,20 +49,20 @@ const classes = getButtonClasses({
 
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
-// if link is disabled/loading, prevent navigation + focus
-if (Tag === "a" && isDisabled) {
-  delete (rest as any).href;
-  (rest as any).tabindex = -1;
-}
-
-const type = Tag === "button" ? (rest.type ?? "button") : undefined;
+const finalType = Tag === "button" ? (type ?? "button") : undefined;
+const finalHref = Tag === "a" && !isDisabled ? href : undefined;
+const finalTabIndex = Tag === "a" && isDisabled ? -1 : tabindex;
 ---
 
 <Tag
   class={finalClass}
+  href={finalHref}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
   disabled={Tag === "button" ? isDisabled : undefined}
   aria-disabled={isDisabled ? "true" : undefined}
-  type={type}
+  tabindex={finalTabIndex}
   {...rest}
 >
   <slot />


### PR DESCRIPTION
This improvement enhances the `SpButton` component by expanding its polymorphic capabilities and ensuring strict HTML attribute integrity.

Key changes:
1. **Expanded Polymorphism**: Added support for `div` and `li` elements via the `as` prop, allowing `SpButton` to be used in more semantic contexts (e.g., as part of a list or a generic container).
2. **Strict Attribute Guarding**: Refactored the template to ensure that element-specific attributes like `href`, `target`, and `rel` are only rendered when the component is an `<a>` tag, and `type` or `disabled` are only rendered for `<button>` tags. This prevents invalid HTML attributes from leaking into the DOM.
3. **Improved Disabled Link Handling**: Implemented a declarative approach to disable links. When `Tag === "a"` and the button is disabled or loading, the `href` is suppressed and `tabindex` is set to `-1` to prevent navigation and focus, matching accessible button behavior.
4. **Button Type Defaulting**: Guaranteed that the `type` attribute defaults to `"button"` only when rendering as a native `<button>` element, preventing accidental form submissions while avoiding invalid attributes on other element types.
5. **Code Quality**: Removed manual object mutations (`delete rest.href`) in favor of cleaner, declarative variable assignments in the component frontmatter.

These changes were verified by building the core library and testing against the `examples/` project using Playwright to inspect DOM attributes across various rendering configurations.

---
*PR created automatically by Jules for task [6893016784659829861](https://jules.google.com/task/6893016784659829861) started by @bradpotts*