### PR TITLE
Expand polymorphic support for SpTestimonial

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -10,7 +10,7 @@ import {
 } from "@phcdevworks/spectre-ui";
 
 interface SpTestimonialProps extends TestimonialRecipeOptions {
-  as?: "div" | "section" | "article";
+  as?: "div" | "section" | "article" | "aside" | "li";
   class?: string;
   [key: string]: any;
 }


### PR DESCRIPTION
This change expands the polymorphic capabilities of the `SpTestimonial` component by adding support for `aside` and `li` tags. This allows developers to use the component in more semantic contexts, such as testimonials in a sidebar or within a list. The change is strictly a type and template update, adhering to the "thin wrapper" strategy and maintaining zero CSS logic within the Astro component.

---
*PR created automatically by Jules for task [4590220004444847073](https://jules.google.com/task/4590220004444847073) started by @bradpotts*