### PR TITLE
Expand polymorphic support for SpTestimonial

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -9,8 +9,10 @@ import {
   type TestimonialRecipeOptions,
 } from "@phcdevworks/spectre-ui";
 
+type SpTestimonialElement = "div" | "section" | "article" | "aside" | "li";
+
 interface SpTestimonialProps extends TestimonialRecipeOptions {
-  as?: "div" | "section" | "article";
+  as?: SpTestimonialElement;
   class?: string;
   [key: string]: any;
 }


### PR DESCRIPTION
Expanded the polymorphic `as` prop in `SpTestimonial.astro` to support `aside` and `li` elements, enhancing its semantic flexibility. verified the change by running `npm run build`.

---
*PR created automatically by Jules for task [2798642207543316777](https://jules.google.com/task/2798642207543316777) started by @bradpotts*