### PR TITLE
feat(badge): add loading prop support to SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -16,6 +16,8 @@ interface SpBadgeProps extends BadgeRecipeOptions {
   datetime?: string;
   "aria-label"?: string;
 
+  loading?: boolean;
+
   [key: string]: any;
 }
 
@@ -24,6 +26,7 @@ const {
   size,
   interactive,
   disabled,
+  loading,
   as: Tag = "span",
   class: className,
   href,
@@ -35,16 +38,19 @@ const {
   ...rest
 } = Astro.props as SpBadgeProps;
 
+const isBadgeDisabled = disabled || loading;
+
 const classes = getBadgeClasses({
   variant,
   size,
   interactive,
-  disabled,
+  disabled: isBadgeDisabled,
+  loading,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
-const finalHref = Tag === "a" && !disabled ? href : undefined;
+const finalHref = Tag === "a" && !isBadgeDisabled ? href : undefined;
 ---
 
 <Tag
@@ -53,8 +59,8 @@ const finalHref = Tag === "a" && !disabled ? href : undefined;
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
-  disabled={Tag === "button" && disabled ? true : undefined}
-  aria-disabled={disabled ? "true" : undefined}
+  disabled={Tag === "button" && isBadgeDisabled ? true : undefined}
+  aria-disabled={isBadgeDisabled ? "true" : undefined}
   aria-label={ariaLabel}
   datetime={Tag === "time" ? datetime : undefined}
   {...rest}


### PR DESCRIPTION
This PR adds support for a `loading` prop to the `SpBadge` component. It aligns with the upstream `@phcdevworks/spectre-ui` contract where the `BadgeRecipeOptions` already includes a `loading` property.

Changes:
- Destructured `loading` from `Astro.props`.
- Updated `SpBadgeProps` interface to include `loading`.
- Implemented `isBadgeDisabled` which is true if either `disabled` or `loading` is provided.
- Ensured `href` is removed from `<a>` tags and `disabled` attribute is added to `<button>` tags when in a loading state.
- Passed the `loading` state to `getBadgeClasses` to apply the appropriate CSS classes.
- Verified that no extra attributes like `loading` leak into the DOM via `...rest`.

Verified via `npm run build` and `npm run typecheck`. Visual verification was performed by temporarily adding a loading badge to the examples page and checking DOM attributes via Playwright.

---
*PR created automatically by Jules for task [11523572318552709469](https://jules.google.com/task/11523572318552709469) started by @bradpotts*