### PR TITLE
Add loading prop to SpIconBox component

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -16,7 +16,7 @@
     },
     "..": {
       "name": "@phcdevworks/spectre-ui-astro",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "funding": [
         {
           "type": "github",
@@ -29,7 +29,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@phcdevworks/spectre-ui": "^1.1.0"
+        "@phcdevworks/spectre-ui": "^1.1.1"
       },
       "devDependencies": {
         "@types/chroma-js": "^3.1.2",

--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -13,6 +13,7 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
   rel?: string;
 
   type?: "button" | "submit" | "reset";
+  loading?: boolean;
 
   [key: string]: any;
 }
@@ -21,6 +22,7 @@ const {
   variant,
   size,
   disabled,
+  loading,
   as: Tag = "span",
   class: className,
   href,
@@ -30,20 +32,29 @@ const {
   ...attrs
 } = Astro.props as SpIconBoxProps;
 
-const classes = getIconBoxClasses({ variant, size, disabled });
+const isIconBoxDisabled = disabled || loading;
+
+const classes = getIconBoxClasses({
+  variant,
+  size,
+  disabled: isIconBoxDisabled,
+  loading,
+});
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
+const finalHref = Tag === "a" && !isIconBoxDisabled ? href : undefined;
 ---
 
 <Tag
   class={finalClass}
-  href={Tag === "a" ? href : undefined}
+  href={finalHref}
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
-  disabled={Tag === "button" && disabled ? true : undefined}
-  aria-disabled={disabled ? "true" : undefined}
+  disabled={Tag === "button" && isIconBoxDisabled ? true : undefined}
+  aria-disabled={isIconBoxDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
   {...attrs}
 >
   <slot />


### PR DESCRIPTION
This change introduces the `loading` prop to the `SpIconBox` component, aligning it with other interactive components like `SpBadge`. It ensures that the component's visual state, accessibility attributes, and behavior (e.g., link navigation) are all correctly synchronized with the loading and disabled states. The implementation follows the library's patterns for polymorphic components and strict attribute guarding.

---
*PR created automatically by Jules for task [17109198667873682262](https://jules.google.com/task/17109198667873682262) started by @bradpotts*