### PR TITLE
Improve SpRating accessibility and loading support

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -33,8 +33,7 @@ interface SpRatingProps extends RatingRecipeOptions {
   rel?: string;
 
   type?: "button" | "submit" | "reset";
-
-  disabled?: boolean;
+  tabindex?: number;
 
   [key: string]: any;
 }
@@ -49,14 +48,22 @@ const {
   rel,
   type,
   disabled,
+  loading,
+  tabindex,
   ...rest
 } = Astro.props as SpRatingProps;
 
-// Pass an empty options object to ensure future-proofing if RatingRecipeOptions gains properties
-const classes = getRatingClasses({});
+const isRatingDisabled = disabled || loading;
+
+const classes = getRatingClasses({
+  disabled: isRatingDisabled,
+  loading,
+});
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
+const finalHref = Tag === "a" && !isRatingDisabled ? href : undefined;
+const finalTabIndex = Tag === "a" && isRatingDisabled ? -1 : tabindex;
 
 const starsClasses = getRatingStarsClasses();
 const textClasses = getRatingTextClasses();
@@ -66,12 +73,14 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
 
 <Tag
   class={finalClass}
-  href={Tag === "a" ? href : undefined}
+  href={finalHref}
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
-  disabled={Tag === "button" && disabled ? true : undefined}
-  aria-disabled={disabled ? "true" : undefined}
+  disabled={Tag === "button" && isRatingDisabled ? true : undefined}
+  aria-disabled={isRatingDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
+  tabindex={finalTabIndex}
   {...rest}
 >
   <div class={starsClasses}>


### PR DESCRIPTION
This PR improves the `SpRating` component by aligning it with the core Spectre UI contract and enhancing its accessibility features. Key changes include:
- Support for the `loading` state, which correctly updates the component's classes and accessibility attributes.
- Improved polymorphic behavior: when rendered as an `<a>` tag in a disabled or loading state, the `href` attribute is removed and `tabindex={-1}` is applied to prevent navigation and focus.
- Addition of `aria-busy` and `aria-disabled` attributes to inform assistive technologies of the component's state.
- Strict attribute guarding to ensure that component-specific props (like `value`, `max`, and `loading`) are not spread onto the underlying HTML element.
- Full type-safety through the `SpRatingProps` interface extending `RatingRecipeOptions`.

---
*PR created automatically by Jules for task [13795343635948179235](https://jules.google.com/task/13795343635948179235) started by @bradpotts*