### PR TITLE
Add `loading` prop to `SpInput` component

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -21,6 +21,7 @@ interface SpInputProps extends InputRecipeOptions {
   id?: string;
   class?: string;
   disabled?: boolean;
+  loading?: boolean;
   [key: string]: any;
 }
 
@@ -36,10 +37,11 @@ const {
   id,
   class: className,
   disabled,
+  loading,
   ...rest
 } = Astro.props as SpInputProps;
 
-const isInputDisabled = disabled || state === "disabled";
+const isInputDisabled = disabled || state === "disabled" || loading;
 
 const inputId = id ?? `sp-input-${Math.random().toString(36).slice(2)}`;
 
@@ -49,7 +51,7 @@ const errorId = `${inputId}-error`;
 const describedBy = errorMessage ? errorId : helperText ? helperId : undefined;
 
 const classes = getInputClasses({
-  state: isInputDisabled ? "disabled" : state,
+  state: loading ? "loading" : isInputDisabled ? "disabled" : state,
   size,
   fullWidth,
   pill,
@@ -73,6 +75,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
     aria-describedby={describedBy}
     disabled={isInputDisabled}
     aria-disabled={isInputDisabled ? "true" : undefined}
+    aria-busy={loading ? "true" : undefined}
     {...rest}
   />
 


### PR DESCRIPTION
I have added a new `loading` prop to the `SpInput` component. This prop provides a dedicated loading state for the input, aligning it with other components like `SpButton` and `SpBadge`. When `loading` is true, the input is automatically disabled, receives the `sp-input--loading` class via the UI recipe, and is marked with `aria-busy="true"` and `aria-disabled="true"` for accessibility.

Key changes:
- Updated `SpInputProps` in `src/components/SpInput.astro` to include `loading`.
- Refined the internal `isInputDisabled` check to account for the `loading` state.
- Updated the call to `getInputClasses` to pass the `"loading"` state when appropriate.
- Added the `aria-busy` attribute to the rendered `<input>` element.

I have verified the change by building the examples project and inspecting the rendered HTML output using Playwright, confirming that all attributes and classes are correctly applied. I also ensured that no unrelated files (like `package-lock.json`) were modified in the final submission to maintain a strict blast radius of one `.astro` file.

---
*PR created automatically by Jules for task [12181338899748153688](https://jules.google.com/task/12181338899748153688) started by @bradpotts*