### PR TITLE
Add loading support and improve accessibility for SpPricingCard

### DIFF
--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -31,6 +31,8 @@ interface SpPricingCardProps extends PricingCardRecipeOptions {
   rel?: string;
 
   type?: "button" | "submit" | "reset";
+  tabindex?: number;
+  "aria-label"?: string;
 
   [key: string]: any;
 }
@@ -38,19 +40,30 @@ interface SpPricingCardProps extends PricingCardRecipeOptions {
 const {
   featured,
   disabled,
+  loading,
   as: Tag = "div",
   class: className,
   href,
   target,
   rel,
   type,
+  tabindex,
+  "aria-label": ariaLabel,
   ...rest
 } = Astro.props as SpPricingCardProps;
 
-const classes = getPricingCardClasses({ featured, disabled });
+const isPricingCardDisabled = disabled || loading;
+
+const classes = getPricingCardClasses({
+  featured,
+  disabled: isPricingCardDisabled,
+  loading,
+});
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
+const finalHref = Tag === "a" && !isPricingCardDisabled ? href : undefined;
+const finalTabIndex = Tag === "a" && isPricingCardDisabled ? -1 : tabindex;
 
 const badgeClasses = getPricingCardBadgeClasses();
 const priceContainerClasses = getPricingCardPriceContainerClasses();
@@ -60,12 +73,15 @@ const descriptionClasses = getPricingCardDescriptionClasses();
 
 <Tag
   class={finalClass}
-  href={Tag === "a" ? href : undefined}
+  href={finalHref}
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
-  disabled={Tag === "button" && disabled ? true : undefined}
-  aria-disabled={disabled ? "true" : undefined}
+  disabled={Tag === "button" && isPricingCardDisabled ? true : undefined}
+  aria-disabled={isPricingCardDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
+  aria-label={ariaLabel}
+  tabindex={finalTabIndex}
   {...rest}
 >
   <slot name="header" />


### PR DESCRIPTION
Implemented missing `loading` prop support in `SpPricingCard.astro` and aligned its accessibility features with other components in the library. This includes adding `aria-label` and `tabindex` support, as well as enforcing strict attribute guarding for disabled and loading states to prevent accidental interactions and ensure a consistent user experience.

---
*PR created automatically by Jules for task [15312146081896130856](https://jules.google.com/task/15312146081896130856) started by @bradpotts*