### PR TITLE
Improve SpCard states and accessibility support

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -27,6 +27,10 @@ interface SpCardProps extends CardRecipeOptions {
   tabindex?: number;
   "aria-label"?: string;
 
+  loading?: boolean;
+  hovered?: boolean;
+  focused?: boolean;
+
   [key: string]: any;
 }
 
@@ -36,6 +40,9 @@ const {
   padded,
   fullHeight,
   disabled,
+  loading,
+  hovered,
+  focused,
   as: Tag = "div",
   class: className,
   href,
@@ -47,12 +54,23 @@ const {
   ...rest
 } = Astro.props as SpCardProps;
 
-const classes = getCardClasses({ variant, interactive, padded, fullHeight, disabled });
+const isCardDisabled = disabled || loading;
+
+const classes = getCardClasses({
+  variant,
+  interactive,
+  padded,
+  fullHeight,
+  disabled: isCardDisabled,
+  loading,
+  hovered,
+  focused,
+});
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
-const finalHref = Tag === "a" && !disabled ? href : undefined;
-const finalTabIndex = Tag === "a" && disabled ? -1 : tabindex;
+const finalHref = Tag === "a" && !isCardDisabled ? href : undefined;
+const finalTabIndex = Tag === "a" && isCardDisabled ? -1 : tabindex;
 ---
 
 <Tag
@@ -61,8 +79,9 @@ const finalTabIndex = Tag === "a" && disabled ? -1 : tabindex;
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
-  disabled={Tag === "button" && disabled ? true : undefined}
-  aria-disabled={disabled ? "true" : undefined}
+  disabled={Tag === "button" && isCardDisabled ? true : undefined}
+  aria-disabled={isCardDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
   tabindex={finalTabIndex}
   {...rest}

--- a/tests/sp-card-improvement.test.ts
+++ b/tests/sp-card-improvement.test.ts
@@ -1,0 +1,51 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getCardClasses } from "@phcdevworks/spectre-ui";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpCard from "../src/components/SpCard.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpCard improvement verification", () => {
+  it("renders with loading state correctly", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        loading: true,
+        variant: "outline",
+      },
+    });
+
+    expect(html).toContain(getCardClasses({ variant: "outline", loading: true, disabled: true }));
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('aria-disabled="true"');
+  });
+
+  it("handles loading links safely", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        as: "a",
+        href: "https://example.com",
+        loading: true,
+      },
+    });
+
+    expect(html).not.toContain('href="https://example.com"');
+    expect(html).toContain('tabindex="-1"');
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("passes hovered and focused states to the recipe", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        hovered: true,
+        focused: true,
+      },
+    });
+
+    expect(html).toContain(getCardClasses({ hovered: true, focused: true }));
+  });
+});


### PR DESCRIPTION
This PR improves the `SpCard` component by adding support for missing states (`loading`, `hovered`, `focused`) defined in the upstream `@phcdevworks/spectre-ui` recipe. It also enhances accessibility and SSR safety by:

1.  **Unifying Inactive States:** Introduces `isCardDisabled` (a union of `disabled` and `loading`) to consistently handle interaction guarding.
2.  **Attribute Guarding:** Safely nullifies `href` and sets `tabindex="-1"` for anchor-based cards when disabled or loading.
3.  **Loading Accessibility:** Adds `aria-busy="true"` when the card is in a loading state.
4.  **Recipe Alignment:** Ensures all relevant states are passed to `getCardClasses` for correct visual representation.
5.  **Test Coverage:** Includes a new test file `tests/sp-card-improvement.test.ts` to verify the rendered HTML structure and attribute logic.

---
*PR created automatically by Jules for task [5703766567767501759](https://jules.google.com/task/5703766567767501759) started by @bradpotts*