### PR TITLE
Improve SpButton Accessibility and Prop Passthrough

### DIFF
--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -25,6 +25,8 @@ const {
   disabled,
   iconOnly,
   pill,
+  hovered,
+  active,
   as: Tag = "button",
   class: className,
   href,
@@ -45,13 +47,15 @@ const classes = getButtonClasses({
   disabled: isDisabled,
   iconOnly,
   pill,
+  hovered,
+  active,
 });
 
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isDisabled ? -1 : tabindex;
 ---
 
 <Tag
@@ -61,7 +65,9 @@ const finalTabIndex = Tag === "a" && isDisabled ? -1 : tabindex;
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" ? isDisabled : undefined}
+  role={Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
   tabindex={finalTabIndex}
   {...rest}
 >

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -154,4 +154,21 @@ describe("SSR rendering", () => {
     expect(html).toContain('tabindex="-1"');
     expect(html).not.toContain('href="/docs"');
   });
+
+  it("renders SpButton with role='button' for non-native elements and handles hovered/active props", async () => {
+    const html = await container.renderToString(SpButton, {
+      props: {
+        as: "span",
+        hovered: true,
+        active: true,
+        loading: true,
+      },
+    });
+
+    expect(html).toContain(getButtonClasses({ hovered: true, active: true, loading: true, disabled: true }));
+    expect(html).toContain('role="button"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain('tabindex="-1"');
+  });
 });


### PR DESCRIPTION
This change improves the SpButton component by enhancing its accessibility (role, aria-busy, tabindex) and aligning its prop passthrough with the upstream Spectre UI contract (hovered, active props). It also adds corresponding test cases to ensure SSR rendering correctness.

---
*PR created automatically by Jules for task [2249040645221607941](https://jules.google.com/task/2249040645221607941) started by @bradpotts*