### PR TITLE
Improve SpBadge accessibility and prop-forwarding

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -28,6 +28,7 @@ const {
   interactive,
   disabled,
   loading,
+  hovered,
   as: Tag = "span",
   class: className,
   href,
@@ -48,12 +49,13 @@ const classes = getBadgeClasses({
   interactive,
   disabled: isBadgeDisabled,
   loading,
+  hovered,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isBadgeDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isBadgeDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isBadgeDisabled ? -1 : tabindex;
 ---
 
 <Tag
@@ -63,6 +65,7 @@ const finalTabIndex = Tag === "a" && isBadgeDisabled ? -1 : tabindex;
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isBadgeDisabled ? true : undefined}
+  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isBadgeDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -155,6 +155,22 @@ describe("SSR rendering", () => {
     expect(html).not.toContain('href="/docs"');
   });
 
+  it("renders SpBadge with upstream classes and accessibility improvements", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        as: "span",
+        interactive: true,
+        hovered: true,
+        disabled: true,
+      },
+    });
+
+    expect(html).toContain(getBadgeClasses({ interactive: true, hovered: true, disabled: true }));
+    expect(html).toContain('role="button"');
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain('tabindex="-1"');
+  });
+
   it("renders SpButton with role='button' for non-native elements and handles hovered/active props", async () => {
     const html = await container.renderToString(SpButton, {
       props: {


### PR DESCRIPTION
This change improves the `SpBadge` component by aligning it with the upstream `BadgeRecipeOptions` contract and enhancing its accessibility. Specifically, it adds support for the `hovered` prop, ensures proper `tabindex` management for disabled interactive elements across all polymorphic tags, and applies the correct `role="button"` for custom interactive badges.

---
*PR created automatically by Jules for task [1750813555072131043](https://jules.google.com/task/1750813555072131043) started by @bradpotts*