### PR TITLE
Improve SpIconBox accessibility and prop forwarding

### DIFF
--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -14,7 +14,7 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
-  loading?: boolean;
+  "aria-label"?: string;
 
   [key: string]: any;
 }
@@ -22,8 +22,12 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 const {
   variant,
   size,
+  interactive,
   disabled,
   loading,
+  hovered,
+  focused,
+  active,
   as: Tag = "span",
   class: className,
   href,
@@ -31,6 +35,7 @@ const {
   rel,
   type,
   tabindex,
+  "aria-label": ariaLabel,
   ...attrs
 } = Astro.props as SpIconBoxProps;
 
@@ -39,14 +44,18 @@ const isIconBoxDisabled = disabled || loading;
 const classes = getIconBoxClasses({
   variant,
   size,
+  interactive,
   disabled: isIconBoxDisabled,
   loading,
+  hovered,
+  focused,
+  active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isIconBoxDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isIconBoxDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isIconBoxDisabled ? -1 : tabindex;
 ---
 
 <Tag
@@ -56,8 +65,10 @@ const finalTabIndex = Tag === "a" && isIconBoxDisabled ? -1 : tabindex;
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isIconBoxDisabled ? true : undefined}
+  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isIconBoxDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
+  aria-label={ariaLabel}
   tabindex={finalTabIndex}
   {...attrs}
 >

--- a/tests/sp-icon-box-improvement.test.ts
+++ b/tests/sp-icon-box-improvement.test.ts
@@ -1,0 +1,82 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getIconBoxClasses } from "@phcdevworks/spectre-ui";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpIconBox from "../src/components/SpIconBox.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpIconBox improvements", () => {
+  it("renders with new recipe props", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: {
+        interactive: true,
+        hovered: true,
+        focused: true,
+        active: true,
+      },
+    });
+
+    expect(html).toContain(
+      getIconBoxClasses({
+        interactive: true,
+        hovered: true,
+        focused: true,
+        active: true,
+      }),
+    );
+  });
+
+  it("applies role='button' for interactive non-native elements", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: {
+        as: "span",
+        interactive: true,
+      },
+    });
+
+    expect(html).toContain('role="button"');
+  });
+
+  it("renders aria-label", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: {
+        "aria-label": "Close",
+      },
+    });
+
+    expect(html).toContain('aria-label="Close"');
+  });
+
+  it("applies correct tabindex guarding for disabled non-button elements", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: {
+        as: "div",
+        disabled: true,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("does not apply role='button' to native buttons or anchors", async () => {
+    const buttonHtml = await container.renderToString(SpIconBox, {
+      props: {
+        as: "button",
+        interactive: true,
+      },
+    });
+    expect(buttonHtml).not.toContain('role="button"');
+
+    const anchorHtml = await container.renderToString(SpIconBox, {
+      props: {
+        as: "a",
+        interactive: true,
+      },
+    });
+    expect(anchorHtml).not.toContain('role="button"');
+  });
+});


### PR DESCRIPTION
This PR improves the `SpIconBox` component by aligning its prop interface with the upstream `@phcdevworks/spectre-ui` recipe and enhancing its accessibility. Specifically, it adds support for missing interactive state props and the `aria-label` attribute, correctly applies `role="button"` to non-native elements when they are interactive, and ensures proper focus management via `tabindex` when disabled. A new test file has been added to verify these changes.

---
*PR created automatically by Jules for task [13373078646224871156](https://jules.google.com/task/13373078646224871156) started by @bradpotts*