### PR TITLE
Improve SpInput prop forwarding and prevent attribute leakage

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@phcdevworks/spectre-ui": "^1.1.2",
+    "@phcdevworks/spectre-ui": "^1.2.0",
     "@phcdevworks/spectre-ui-astro": "file:..",
     "astro": "^6.1.5",
     "typescript": "^6.0.2"

--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -18,6 +18,8 @@ const {
   class: className,
   disabled,
   loading,
+  focused,
+  hovered,
   ...rest
 } = Astro.props as SpInputProps;
 
@@ -36,6 +38,8 @@ const classes = getInputClasses({
   size,
   fullWidth,
   pill,
+  focused,
+  hovered,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 ---

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -16,6 +16,8 @@ interface SpInputBaseProps extends InputRecipeOptions {
   class?: string;
   disabled?: boolean;
   loading?: boolean;
+  focused?: boolean;
+  hovered?: boolean;
   [key: string]: unknown;
 }
 

--- a/tests/sp-input-improvement.test.ts
+++ b/tests/sp-input-improvement.test.ts
@@ -1,0 +1,33 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getInputClasses } from "@phcdevworks/spectre-ui";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpInput from "../src/components/SpInput.astro";
+import type { SpInputProps } from "../src/components/sp-input.shared";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpInput improvement verification", () => {
+  it("passes hovered and focused states to the recipe and prevents attribute leakage", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        hovered: true,
+        focused: true,
+      } as SpInputProps,
+    });
+
+    // Verify classes are applied
+    expect(html).toContain(getInputClasses({ hovered: true, focused: true }));
+
+    // Verify attributes do NOT leak to the input element
+    // Note: Astro might render 'focused="true"' or just 'focused'
+    expect(html).not.toContain('focused="true"');
+    expect(html).not.toContain('hovered="true"');
+    // Also check for the boolean attribute form if applicable, though less likely for these custom prop names
+    expect(html).not.toMatch(/<input[^>]*\bfocused\b/);
+    expect(html).not.toMatch(/<input[^>]*\bhovered\b/);
+  });
+});


### PR DESCRIPTION
This PR improves the `SpInput` component by properly handling the `focused` and `hovered` props. 

Key changes:
1.  **Prop Forwarding:** The `focused` and `hovered` props are now correctly passed to the `getInputClasses` recipe from `@phcdevworks/spectre-ui`, ensuring that the input component can be rendered in these states (useful for documentation or SSR-safe visual testing).
2.  **Attribute Guarding:** These props are now explicitly destructured from `Astro.props`, which prevents them from being included in the `...rest` spread that is applied to the underlying `<input>` element. This ensures that custom Spectre props do not leak as invalid HTML attributes.
3.  **Typing:** The `SpInputBaseProps` interface was updated to include these props, aligning the TypeScript definitions with the component logic.
4.  **Contract Alignment:** A version mismatch for `@phcdevworks/spectre-ui` in the `examples/` directory was corrected to align with the package's peer dependency contract and fix pre-existing test failures.
5.  **Verification:** A new test suite `tests/sp-input-improvement.test.ts` was added to verify both the correct application of classes and the prevention of attribute leakage.

---
*PR created automatically by Jules for task [12222095667966284443](https://jules.google.com/task/12222095667966284443) started by @bradpotts*