### PR TITLE
Improve SpButton accessibility and prop forwarding

### DIFF
--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -14,6 +14,7 @@ interface SpButtonProps extends ButtonRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  "aria-label"?: string;
   [key: string]: any;
 }
 
@@ -26,6 +27,7 @@ const {
   iconOnly,
   pill,
   hovered,
+  focused,
   active,
   as: Tag = "button",
   class: className,
@@ -34,6 +36,7 @@ const {
   rel,
   type,
   tabindex,
+  "aria-label": ariaLabel,
   ...rest
 } = Astro.props as SpButtonProps;
 
@@ -48,6 +51,7 @@ const classes = getButtonClasses({
   iconOnly,
   pill,
   hovered,
+  focused,
   active,
 });
 
@@ -68,6 +72,7 @@ const finalTabIndex = Tag !== "button" && isDisabled ? -1 : tabindex;
   role={Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
+  aria-label={ariaLabel}
   tabindex={finalTabIndex}
   {...rest}
 >

--- a/tests/sp-button-improvement.test.ts
+++ b/tests/sp-button-improvement.test.ts
@@ -1,0 +1,47 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+import SpButton from "../src/components/SpButton.astro";
+
+describe("SpButton improvements", () => {
+  it("renders SpButton with aria-label", async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(SpButton, {
+      props: {
+        "aria-label": "Close modal",
+      },
+    });
+
+    expect(html).toContain('aria-label="Close modal"');
+  });
+
+  it("applies focused state and does not leak focused prop to DOM", async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(SpButton, {
+      props: {
+        focused: true,
+      },
+    });
+
+    // Should contain the focus-related class from the recipe
+    // Based on spectre-ui conventions, it usually includes "focused" or "focus" in the class string
+    // but the exact class depends on the upstream recipe.
+    // Most importantly, it should NOT have focused="true" as an attribute.
+    expect(html).not.toContain('focused="true"');
+    expect(html).not.toContain('focused="focused"');
+  });
+
+  it("handles polymorphic tag with aria-label", async () => {
+    const container = await AstroContainer.create();
+    const html = await container.renderToString(SpButton, {
+      props: {
+        as: "a",
+        href: "/dashboard",
+        "aria-label": "Go to Dashboard",
+      },
+    });
+
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/dashboard"');
+    expect(html).toContain('aria-label="Go to Dashboard"');
+  });
+});


### PR DESCRIPTION
This PR improves the `SpButton` component by adding explicit support for the `aria-label` attribute and ensuring that the `focused` state prop is correctly used for styling but does not leak into the DOM as a non-standard attribute.

Key changes:
- Updated `SpButtonProps` to include `aria-label`.
- Destructured `focused` and `aria-label` from `Astro.props`.
- Passed `focused` to `getButtonClasses`.
- Applied `aria-label` to the rendered `<Tag>`.
- Added a new test file `tests/sp-button-improvement.test.ts` to verify these improvements.

---
*PR created automatically by Jules for task [7246745601859721702](https://jules.google.com/task/7246745601859721702) started by @bradpotts*