### PR TITLE
Improve SpCard accessibility and attribute guarding

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -70,7 +70,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isCardDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isCardDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isCardDisabled ? -1 : tabindex;
 ---
 
 <Tag
@@ -80,6 +80,7 @@ const finalTabIndex = Tag === "a" && isCardDisabled ? -1 : tabindex;
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isCardDisabled ? true : undefined}
+  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isCardDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/sp-card-v2-improvement.test.ts
+++ b/tests/sp-card-v2-improvement.test.ts
@@ -1,0 +1,76 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it, beforeAll } from "vitest";
+import SpCard from "../src/components/SpCard.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpCard accessibility and attribute guarding improvements", () => {
+  it("applies role='button' when interactive and not a native button or link", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        interactive: true,
+        as: "div",
+      },
+    });
+
+    expect(html).toContain('role="button"');
+  });
+
+  it("does not apply role='button' to native buttons or links even if interactive", async () => {
+    const buttonHtml = await container.renderToString(SpCard, {
+      props: {
+        interactive: true,
+        as: "button",
+      },
+    });
+    expect(buttonHtml).not.toContain('role="button"');
+
+    const linkHtml = await container.renderToString(SpCard, {
+      props: {
+        interactive: true,
+        as: "a",
+      },
+    });
+    expect(linkHtml).not.toContain('role="button"');
+  });
+
+  it("guards tabindex for non-native elements when disabled", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        as: "div",
+        disabled: true,
+        tabindex: 0,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("guards tabindex for links when disabled", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: {
+        as: "a",
+        disabled: true,
+        tabindex: 0,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("does not force tabindex='-1' on native buttons when disabled", async () => {
+    // Native buttons handle disabled state naturally
+    const html = await container.renderToString(SpCard, {
+      props: {
+        as: "button",
+        disabled: true,
+      },
+    });
+
+    expect(html).not.toContain('tabindex="-1"');
+  });
+});


### PR DESCRIPTION
This change improves the accessibility of the `SpCard` component by ensuring that interactive cards rendered as non-native elements (like `div`) receive the appropriate `role="button"`. It also refines the `tabindex` guarding logic to ensure that any non-native element correctly receives `tabindex="-1"` when in a disabled or loading state, while allowing native buttons to manage their own focus state.

Verified with a new test suite covering native buttons, links, and generic elements.

---
*PR created automatically by Jules for task [2930517484192197059](https://jules.google.com/task/2930517484192197059) started by @bradpotts*