### PR TITLE
feat(SpRating): add support for size prop

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -42,6 +42,7 @@ interface SpRatingProps extends RatingRecipeOptions {
 const {
   value = 0,
   max = 5,
+  size,
   as: Tag = "div",
   class: className,
   href,
@@ -58,6 +59,7 @@ const {
 const isRatingDisabled = disabled || loading;
 
 const classes = getRatingClasses({
+  size,
   disabled: isRatingDisabled,
   loading,
 });


### PR DESCRIPTION
This PR implements an isolated improvement to the `SpRating` component by exposing the `size` prop from the upstream Spectre UI contract.

### Changes:
- Updated `SpRating.astro` to destructure the `size` prop.
- Passed the `size` prop to the `getRatingClasses` recipe function.

This change is purely structural and aligns the Astro adapter with the styling capabilities already provided by the core UI package, without introducing any local styling logic or design tokens.

---
*PR created automatically by Jules for task [5017569302120498269](https://jules.google.com/task/5017569302120498269) started by @bradpotts*