### PR TITLE
Improve tabindex guarding for SpPricingCard

### DIFF
--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -63,7 +63,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isPricingCardDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isPricingCardDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isPricingCardDisabled ? -1 : tabindex;
 
 const badgeClasses = getPricingCardBadgeClasses();
 const priceContainerClasses = getPricingCardPriceContainerClasses();

--- a/tests/sp-pricing-card-improvement.test.ts
+++ b/tests/sp-pricing-card-improvement.test.ts
@@ -1,0 +1,62 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getPricingCardClasses } from "@phcdevworks/spectre-ui";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpPricingCard from "../src/components/SpPricingCard.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpPricingCard improvement verification", () => {
+  it("guards tabindex for non-button tags when disabled", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        as: "div",
+        disabled: true,
+        tabindex: 0,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("guards tabindex for non-button tags when loading", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        as: "section",
+        loading: true,
+        tabindex: 0,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("guards tabindex for anchors when disabled", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        as: "a",
+        href: "https://example.com",
+        disabled: true,
+      },
+    });
+
+    expect(html).not.toContain('href="https://example.com"');
+    expect(html).toContain('tabindex="-1"');
+  });
+
+  it("does not guard tabindex for native buttons", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        as: "button",
+        disabled: true,
+        tabindex: 0,
+      },
+    });
+
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain('disabled');
+  });
+});


### PR DESCRIPTION
This PR improves the accessibility of the `SpPricingCard` component by refining its `tabindex` guarding logic. Previously, it only applied `tabindex="-1"` to disabled anchors. The updated implementation now correctly guards all non-native tags (`Tag !== "button"`) when the component is disabled or loading, ensuring they are removed from keyboard navigation. Native buttons continue to rely on the `disabled` attribute for focus management.

Key changes:
- Modified `finalTabIndex` calculation in `SpPricingCard.astro`.
- Added `tests/sp-pricing-card-improvement.test.ts` to verify the new behavior across different tag types and states.
- Re-generated `dist/` artifacts.

---
*PR created automatically by Jules for task [14535756562338468216](https://jules.google.com/task/14535756562338468216) started by @bradpotts*