### PR TITLE
fix(SpTestimonial): align tabindex guarding with library standards

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -65,7 +65,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isTestimonialDisabled ? href : undefined;
-const finalTabIndex = Tag === "a" && isTestimonialDisabled ? -1 : tabindex;
+const finalTabIndex = Tag !== "button" && isTestimonialDisabled ? -1 : tabindex;
 
 const quoteClasses = getTestimonialQuoteClasses();
 const authorClasses = getTestimonialAuthorClasses();

--- a/tests/testimonial-rendering.test.ts
+++ b/tests/testimonial-rendering.test.ts
@@ -63,4 +63,16 @@ describe("SpTestimonial SSR rendering", () => {
     expect(html).toContain('tabindex="-1"');
     expect(html).not.toContain('href="/testimonials/1"');
   });
+
+  it("applies tabindex='-1' to disabled non-button elements with custom tabindex", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      props: {
+        as: "div",
+        tabindex: 0,
+        disabled: true,
+      },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
 });


### PR DESCRIPTION
### Summary of Changes

This PR fixes an inconsistency in the `SpTestimonial` component's `tabindex` guarding logic. Previously, it only suppressed `tabindex` for anchor (`<a>`) tags when disabled or loading. It has been updated to follow the library's preferred pattern: `Tag !== "button" && isDisabled ? -1 : tabindex`.

### Key Improvements

- **Accessibility:** Ensures that polymorphic non-button wrappers (e.g., `<div as="div" tabindex="0">`) are correctly removed from the focus order when the component is in a disabled or loading state.
- **Consistency:** Aligns `SpTestimonial` with the focus-guarding behavior of other components like `SpCard`, `SpBadge`, and `SpPricingCard`.
- **SSR Safety:** Preserves deterministic markup and handles polymorphic tag types safely.

### Verification Results

- **Build:** `npm run build` passed.
- **Typecheck:** `npm run typecheck` passed.
- **Tests:** `npm test` passed, including a new test case in `tests/testimonial-rendering.test.ts` that specifically verifies `tabindex` suppression for non-anchor elements.

---
*PR created automatically by Jules for task [9384312625567803725](https://jules.google.com/task/9384312625567803725) started by @bradpotts*