### PR TITLE
Improve SpBadge prop forwarding and attribute guarding

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -29,6 +29,8 @@ const {
   disabled,
   loading,
   hovered,
+  focused,
+  active,
   as: Tag = "span",
   class: className,
   href,
@@ -50,6 +52,8 @@ const classes = getBadgeClasses({
   disabled: isBadgeDisabled,
   loading,
   hovered,
+  focused,
+  active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 

--- a/tests/sp-badge-improvement.test.ts
+++ b/tests/sp-badge-improvement.test.ts
@@ -1,0 +1,35 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpBadge from "../src/components/SpBadge.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpBadge improvement verification", () => {
+  it("applies focused class and does not leak the prop to DOM", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        focused: true,
+      },
+    });
+
+    expect(html).toContain("sp-badge--focus");
+    expect(html).not.toContain('focused="true"');
+    expect(html).not.toContain('focused="focused"');
+  });
+
+  it("applies active class and does not leak the prop to DOM", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        active: true,
+      },
+    });
+
+    expect(html).toContain("sp-badge--active");
+    expect(html).not.toContain('active="true"');
+    expect(html).not.toContain('active="active"');
+  });
+});


### PR DESCRIPTION
Improved `SpBadge.astro` by correctly forwarding the `focused` and `active` state props to the styling recipe and preventing them from leaking into the DOM as invalid HTML attributes. Verified the fix with a new unit test and Playwright-based DOM inspection.

---
*PR created automatically by Jules for task [16763632687420899736](https://jules.google.com/task/16763632687420899736) started by @bradpotts*