### PR TITLE
Align SpPricingCard with full UI contract

### DIFF
--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -39,8 +39,12 @@ interface SpPricingCardProps extends PricingCardRecipeOptions {
 
 const {
   featured,
+  interactive,
   disabled,
   loading,
+  hovered,
+  focused,
+  active,
   as: Tag = "div",
   class: className,
   href,
@@ -56,14 +60,23 @@ const isPricingCardDisabled = disabled || loading;
 
 const classes = getPricingCardClasses({
   featured,
+  interactive,
   disabled: isPricingCardDisabled,
   loading,
+  hovered,
+  focused,
+  active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isPricingCardDisabled ? href : undefined;
-const finalTabIndex = Tag !== "button" && isPricingCardDisabled ? -1 : tabindex;
+const finalTabIndex =
+  Tag !== "button" && isPricingCardDisabled
+    ? -1
+    : interactive && Tag !== "button" && Tag !== "a"
+      ? (tabindex ?? 0)
+      : tabindex;
 
 const badgeClasses = getPricingCardBadgeClasses();
 const priceContainerClasses = getPricingCardPriceContainerClasses();
@@ -78,6 +91,7 @@ const descriptionClasses = getPricingCardDescriptionClasses();
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isPricingCardDisabled ? true : undefined}
+  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isPricingCardDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/sp-pricing-card-improvement.test.ts
+++ b/tests/sp-pricing-card-improvement.test.ts
@@ -59,4 +59,36 @@ describe("SpPricingCard improvement verification", () => {
     expect(html).toContain('tabindex="0"');
     expect(html).toContain('disabled');
   });
+
+  it("applies role='button' and default tabindex when interactive", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        as: "div",
+        interactive: true,
+      },
+    });
+
+    expect(html).toContain('role="button"');
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("passes state props to recipe and does not leak them to DOM", async () => {
+    const props = {
+      interactive: true,
+      hovered: true,
+      focused: true,
+      active: true,
+    };
+    const html = await container.renderToString(SpPricingCard, {
+      props,
+    });
+
+    const expectedClasses = getPricingCardClasses(props);
+    expect(html).toContain(expectedClasses);
+
+    expect(html).not.toContain('interactive="true"');
+    expect(html).not.toContain('hovered="true"');
+    expect(html).not.toContain('focused="true"');
+    expect(html).not.toContain('active="true"');
+  });
 });


### PR DESCRIPTION
Aligned `SpPricingCard.astro` with the full `@phcdevworks/spectre-ui` contract by destructuring and forwarding interactive state props. Improved accessibility by adding `role="button"` and default `tabindex="0"` for non-native interactive elements, while maintaining existing safety guards for disabled and loading states.

---
*PR created automatically by Jules for task [6093762700612050183](https://jules.google.com/task/6093762700612050183) started by @bradpotts*