### PR TITLE
Improve SpRating accessibility and state prop forwarding

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -43,14 +43,18 @@ const {
   value = 0,
   max = 5,
   size,
+  interactive,
+  disabled,
+  loading,
+  hovered,
+  focused,
+  active,
   as: Tag = "div",
   class: className,
   href,
   target,
   rel,
   type,
-  disabled,
-  loading,
   tabindex,
   "aria-label": ariaLabel,
   ...rest
@@ -60,14 +64,23 @@ const isRatingDisabled = disabled || loading;
 
 const classes = getRatingClasses({
   size,
+  interactive,
   disabled: isRatingDisabled,
   loading,
+  hovered,
+  focused,
+  active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isRatingDisabled ? href : undefined;
-const finalTabIndex = Tag !== "button" && isRatingDisabled ? -1 : tabindex;
+const finalTabIndex =
+  Tag !== "button" && isRatingDisabled
+    ? -1
+    : interactive && Tag !== "button" && Tag !== "a"
+      ? (tabindex ?? 0)
+      : tabindex;
 
 const starsClasses = getRatingStarsClasses();
 const textClasses = getRatingTextClasses();
@@ -82,6 +95,7 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isRatingDisabled ? true : undefined}
+  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isRatingDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/sp-rating-improvement.test.ts
+++ b/tests/sp-rating-improvement.test.ts
@@ -75,3 +75,49 @@ describe("SpRating accessibility improvements", () => {
     expect(htmlDisabledButton).toContain('disabled');
   });
 });
+
+describe("SpRating interactive improvements", () => {
+  it("applies role='button' when interactive is true on a non-native tag", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: {
+        as: "div",
+        interactive: true,
+      },
+    });
+
+    expect(html).toContain('role="button"');
+  });
+
+  it("defaults tabindex to 0 for interactive non-native elements", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: {
+        as: "div",
+        interactive: true,
+      },
+    });
+
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("applies state-related classes when props are passed", async () => {
+    const htmlNormal = await container.renderToString(SpRating, {
+      props: {
+        interactive: true,
+      },
+    });
+
+    const htmlHovered = await container.renderToString(SpRating, {
+      props: {
+        interactive: true,
+        hovered: true,
+      },
+    });
+
+    // We expect the class lists to be different when hovered is true
+    const classNormal = (htmlNormal.match(/class="([^"]+)"/) || [])[1];
+    const classHovered = (htmlHovered.match(/class="([^"]+)"/) || [])[1];
+
+    expect(classNormal).not.toBe(classHovered);
+    expect(classHovered).toBeDefined();
+  });
+});


### PR DESCRIPTION
Modify `src/components/SpRating.astro` to align with `RatingRecipeOptions` and repository standards.
- Update `SpRatingProps` interface to include `interactive`, `hovered`, `focused`, and `active`.
- Update the destructuring of `Astro.props` to include `interactive`, `hovered`, `focused`, and `active`.
- Pass `interactive`, `hovered`, `focused`, and `active` to the `getRatingClasses` function call.
- Add `role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}` to the `<Tag>` element.
- Update `finalTabIndex` logic to follow the repository's advanced pattern.
- Ensure `interactive`, `hovered`, `focused`, and `active` are excluded from the `...rest` spread.
Update `tests/sp-rating-improvement.test.ts` to verify the new interactive behavior.
- Add tests for `role="button"`, `tabindex="0"`, and state-related classes.

---
*PR created automatically by Jules for task [14425950949942783179](https://jules.google.com/task/14425950949942783179) started by @bradpotts*