### PR TITLE
Implement advanced tabindex guarding in SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -59,7 +59,12 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const finalType = Tag === "button" ? (type ?? "button") : undefined;
 const finalHref = Tag === "a" && !isBadgeDisabled ? href : undefined;
-const finalTabIndex = Tag !== "button" && isBadgeDisabled ? -1 : tabindex;
+const finalTabIndex =
+  Tag !== "button" && isBadgeDisabled
+    ? -1
+    : interactive && Tag !== "button" && Tag !== "a"
+      ? (tabindex ?? 0)
+      : tabindex;
 ---
 
 <Tag

--- a/tests/sp-badge-tabindex.test.ts
+++ b/tests/sp-badge-tabindex.test.ts
@@ -1,0 +1,36 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it, beforeAll } from "vitest";
+import SpBadge from "../src/components/SpBadge.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpBadge tabindex guarding", () => {
+  it("should have tabindex=0 when interactive=true and Tag is not a native interactive element", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        interactive: true,
+        as: "div",
+      },
+    });
+
+    // Currently it doesn't have tabindex=0 unless provided
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("should have tabindex=-1 when disabled and Tag is not a button", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        disabled: true,
+        as: "a",
+        href: "https://example.com"
+      },
+    });
+
+    // Currently it might have no tabindex or default tabindex
+    expect(html).toContain('tabindex="-1"');
+  });
+});


### PR DESCRIPTION
This PR improves the `SpBadge` component by implementing the advanced `tabindex` guarding pattern already used in other components like `SpCard` and `SpTestimonial`. 

This ensures that:
1. Interactive badges rendered as non-native elements (e.g., `<div as="div" interactive />`) are keyboard-accessible by defaulting `tabindex` to `0`.
2. Disabled badges rendered as non-native elements (e.g., `<a as="a" disabled />`) are removed from the focus order by setting `tabindex` to `-1`.

Verified with a new test case in `tests/sp-badge-tabindex.test.ts`.

---
*PR created automatically by Jules for task [4629612561111690728](https://jules.google.com/task/4629612561111690728) started by @bradpotts*