### PR TITLE
Add active state prop support to SpInput

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -20,6 +20,7 @@ const {
   loading,
   focused,
   hovered,
+  active,
   ...rest
 } = Astro.props as SpInputProps;
 
@@ -40,6 +41,7 @@ const classes = getInputClasses({
   pill,
   focused,
   hovered,
+  active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 ---

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -18,6 +18,7 @@ interface SpInputBaseProps extends InputRecipeOptions {
   loading?: boolean;
   focused?: boolean;
   hovered?: boolean;
+  active?: boolean;
   [key: string]: unknown;
 }
 

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -11,15 +11,19 @@ beforeAll(async () => {
 });
 
 describe("SpInput state behavior", () => {
-  it("passes hovered and focused states to the recipe without leaking them to DOM", async () => {
+  it("passes hovered, focused, and active states to the recipe without leaking them to DOM", async () => {
     const html = await container.renderToString(SpInput, {
-      props: { hovered: true, focused: true } as SpInputProps,
+      props: { hovered: true, focused: true, active: true } as SpInputProps,
     });
 
-    expect(html).toContain(getInputClasses({ hovered: true, focused: true }));
+    expect(html).toContain(
+      getInputClasses({ hovered: true, focused: true, active: true }),
+    );
     expect(html).not.toContain('focused="true"');
     expect(html).not.toContain('hovered="true"');
-    expect(html).not.toMatch(/<input[^>]*\bfocused\b/);
-    expect(html).not.toMatch(/<input[^>]*\bhovered\b/);
+    expect(html).not.toContain('active="true"');
+    expect(html).not.toMatch(/<input[^>]*\sfocused\b/);
+    expect(html).not.toMatch(/<input[^>]*\shovered\b/);
+    expect(html).not.toMatch(/<input[^>]*\sactive\b/);
   });
 });


### PR DESCRIPTION
This change adds support for the 'active' state prop to the SpInput component, ensuring parity with the upstream @phcdevworks/spectre-ui InputRecipeOptions. The 'active' prop is correctly destructured and passed to the styling recipe, and is prevented from leaking into the DOM as a non-standard attribute.

---
*PR created automatically by Jules for task [18125283468880374690](https://jules.google.com/task/18125283468880374690) started by @bradpotts*