### PR TITLE
Fix SpIconBox tabindex guarding for interactive non-native tags

### DIFF
--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -60,6 +60,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   href,
   type,
   tabindex,
+  interactive,
 });
 ---
 

--- a/tests/sp-icon-box.test.ts
+++ b/tests/sp-icon-box.test.ts
@@ -44,6 +44,14 @@ describe("SpIconBox behavior", () => {
     expect(html).toContain('tabindex="-1"');
   });
 
+  it("applies default tabindex='0' when interactive and non-native tag", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: { as: "span", interactive: true },
+    });
+
+    expect(html).toContain('tabindex="0"');
+  });
+
   it("does not apply role='button' to native buttons or anchors", async () => {
     const buttonHtml = await container.renderToString(SpIconBox, {
       props: { as: "button", interactive: true },


### PR DESCRIPTION
This change ensures that the SpIconBox component correctly receives a default tabindex="0" when it is marked as interactive and rendered as a non-native tag (e.g., span, div). This was previously missing because the interactive prop was not being passed to the resolveInteractiveAttrs helper function.

---
*PR created automatically by Jules for task [6092055763333646341](https://jules.google.com/task/6092055763333646341) started by @bradpotts*