### PR TITLE
fix(SpButton): ensure proper tabindex guarding for polymorphic states

### DIFF
--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -64,6 +64,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   href,
   type,
   tabindex,
+  interactive: true,
 });
 ---
 

--- a/tests/sp-button.test.ts
+++ b/tests/sp-button.test.ts
@@ -35,4 +35,20 @@ describe("SpButton behavior", () => {
     expect(html).toContain('href="/dashboard"');
     expect(html).toContain('aria-label="Go to Dashboard"');
   });
+
+  it("guards tabindex=0 for non-native interactive elements", async () => {
+    const html = await container.renderToString(SpButton, {
+      props: { as: "span" },
+    });
+
+    expect(html).toContain('tabindex="0"');
+  });
+
+  it("guards tabindex=-1 for disabled non-native elements", async () => {
+    const html = await container.renderToString(SpButton, {
+      props: { as: "span", disabled: true },
+    });
+
+    expect(html).toContain('tabindex="-1"');
+  });
 });


### PR DESCRIPTION
This PR fixes an accessibility gap in the `SpButton` component. When the component is rendered as a non-native element (e.g., `<span as="span">`), it was missing the `tabindex` attribute, making it unreachable via keyboard navigation.

Changes:
- Updated `SpButton.astro` to pass `interactive: true` to the `resolveInteractiveAttrs` utility.
- Added regression tests in `tests/sp-button.test.ts` to verify `tabindex` behavior for non-native elements in both enabled and disabled states.

Verified with `npm run build`, `npm run typecheck`, and `npm test`.

---
*PR created automatically by Jules for task [11765613604399379077](https://jules.google.com/task/11765613604399379077) started by @bradpotts*