### PR TITLE
Improve SpPricingCard slot rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,22 +2557,6 @@
         }
       }
     },
-    "node_modules/astro/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",

--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -101,19 +101,31 @@ const descriptionClasses = getPricingCardDescriptionClasses();
 >
   <slot name="header" />
 
-  <div class={badgeClasses}>
-    <slot name="badge" />
-  </div>
+  {
+    Astro.slots.has("badge") && (
+      <div class={badgeClasses}>
+        <slot name="badge" />
+      </div>
+    )
+  }
 
-  <div class={priceContainerClasses}>
-    <div class={priceClasses}>
-      <slot name="price" />
-    </div>
-  </div>
+  {
+    Astro.slots.has("price") && (
+      <div class={priceContainerClasses}>
+        <div class={priceClasses}>
+          <slot name="price" />
+        </div>
+      </div>
+    )
+  }
 
-  <div class={descriptionClasses}>
-    <slot name="description" />
-  </div>
+  {
+    Astro.slots.has("description") && (
+      <div class={descriptionClasses}>
+        <slot name="description" />
+      </div>
+    )
+  }
 
   <slot />
 

--- a/tests/sp-pricing-card.test.ts
+++ b/tests/sp-pricing-card.test.ts
@@ -1,5 +1,10 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
-import { getPricingCardClasses } from "@phcdevworks/spectre-ui";
+import {
+  getPricingCardClasses,
+  getPricingCardBadgeClasses,
+  getPricingCardPriceContainerClasses,
+  getPricingCardDescriptionClasses,
+} from "@phcdevworks/spectre-ui";
 import { beforeAll, describe, expect, it } from "vitest";
 import SpPricingCard from "../src/components/SpPricingCard.astro";
 
@@ -54,7 +59,12 @@ describe("SpPricingCard behavior", () => {
   });
 
   it("passes state props to recipe and does not leak them to DOM", async () => {
-    const props = { interactive: true, hovered: true, focused: true, active: true };
+    const props = {
+      interactive: true,
+      hovered: true,
+      focused: true,
+      active: true,
+    };
     const html = await container.renderToString(SpPricingCard, { props });
 
     expect(html).toContain(getPricingCardClasses(props));
@@ -62,5 +72,34 @@ describe("SpPricingCard behavior", () => {
     expect(html).not.toContain('hovered="true"');
     expect(html).not.toContain('focused="true"');
     expect(html).not.toContain('active="true"');
+  });
+
+  describe("slot behavior", () => {
+    it("does not render empty wrapper divs when slots are not provided", async () => {
+      const html = await container.renderToString(SpPricingCard, {
+        props: {},
+      });
+
+      expect(html).not.toContain(getPricingCardBadgeClasses());
+      expect(html).not.toContain(getPricingCardPriceContainerClasses());
+      expect(html).not.toContain(getPricingCardDescriptionClasses());
+    });
+
+    it("renders wrapper divs when slots are provided", async () => {
+      const html = await container.renderToString(SpPricingCard, {
+        slots: {
+          badge: "Hot",
+          price: "$99",
+          description: "Best deal",
+        },
+      });
+
+      expect(html).toContain(getPricingCardBadgeClasses());
+      expect(html).toContain(getPricingCardPriceContainerClasses());
+      expect(html).toContain(getPricingCardDescriptionClasses());
+      expect(html).toContain("Hot");
+      expect(html).toContain("$99");
+      expect(html).toContain("Best deal");
+    });
   });
 });


### PR DESCRIPTION
I have improved the `SpPricingCard` component by adding conditional rendering for its optional slots. Previously, the wrapper divs for `badge`, `price`, and `description` were always rendered, leading to empty elements in the DOM if those slots were not provided. Using `Astro.slots.has()`, these wrappers are now only rendered when content is actually provided to the slots, resulting in cleaner and more deterministic SSR output.

I have also updated `tests/sp-pricing-card.test.ts` with regression tests to verify this behavior. All tests are passing, and the project builds correctly.

---
*PR created automatically by Jules for task [899259351806844277](https://jules.google.com/task/899259351806844277) started by @bradpotts*