### PR TITLE
Add pill prop support to SpIconBox

### DIFF
--- a/examples/.astro/types.d.ts
+++ b/examples/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -23,6 +23,7 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 const {
   variant,
   size,
+  pill,
   interactive,
   disabled,
   loading,
@@ -45,6 +46,7 @@ const isIconBoxDisabled = disabled || loading;
 const classes = getIconBoxClasses({
   variant,
   size,
+  pill,
   interactive,
   disabled: isIconBoxDisabled,
   loading,

--- a/tests/sp-icon-box.test.ts
+++ b/tests/sp-icon-box.test.ts
@@ -63,4 +63,13 @@ describe("SpIconBox behavior", () => {
     });
     expect(anchorHtml).not.toContain('role="button"');
   });
+
+  it("applies 'pill' class and prevents prop leakage", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: { pill: true },
+    });
+
+    expect(html).toContain(getIconBoxClasses({ pill: true }));
+    expect(html).not.toContain('pill="true"');
+  });
 });


### PR DESCRIPTION
I have improved the `SpIconBox` component by adding support for the `pill` prop, which was already present in the upstream `@phcdevworks/spectre-ui` library but not yet exposed in the Astro adapter.

Key changes:
- Updated `src/components/SpIconBox.astro` to destructure and pass the `pill` prop to `getIconBoxClasses`.
- Added a regression test in `tests/sp-icon-box.test.ts` to verify that the `pill` class is correctly applied and that the prop does not leak as a DOM attribute.
- Verified the implementation with `npm run build`, `npm run typecheck`, and `npm test`.
- Visually verified the change using a Playwright script on the `examples/` project.

This change maintains alignment with the core Spectre UI contracts and preserves the thin-adapter invariant.

---
*PR created automatically by Jules for task [5778065388531859408](https://jules.google.com/task/5778065388531859408) started by @bradpotts*