### PR TITLE
Conditionally render slot wrappers in SpTestimonial

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -99,18 +99,34 @@ const authorTitleClasses = getTestimonialAuthorTitleClasses();
   tabindex={finalTabIndex}
   {...rest}
 >
-  <div class={quoteClasses}>
-    <slot name="quote" />
-  </div>
-  <div class={authorClasses}>
-    <slot name="author-image" />
-    <div class={authorInfoClasses}>
-      <div class={authorNameClasses}>
-        <slot name="author-name" />
+  {
+    Astro.slots.has("quote") && (
+      <div class={quoteClasses}>
+        <slot name="quote" />
       </div>
-      <div class={authorTitleClasses}>
-        <slot name="author-title" />
+    )
+  }
+  {
+    (Astro.slots.has("author-image") ||
+      Astro.slots.has("author-name") ||
+      Astro.slots.has("author-title")) && (
+      <div class={authorClasses}>
+        <slot name="author-image" />
+        {(Astro.slots.has("author-name") || Astro.slots.has("author-title")) && (
+          <div class={authorInfoClasses}>
+            {Astro.slots.has("author-name") && (
+              <div class={authorNameClasses}>
+                <slot name="author-name" />
+              </div>
+            )}
+            {Astro.slots.has("author-title") && (
+              <div class={authorTitleClasses}>
+                <slot name="author-title" />
+              </div>
+            )}
+          </div>
+        )}
       </div>
-    </div>
-  </div>
+    )
+  }
 </Tag>

--- a/tests/sp-testimonial.test.ts
+++ b/tests/sp-testimonial.test.ts
@@ -111,4 +111,14 @@ describe("SpTestimonial interactive behavior", () => {
     expect(html).not.toContain('target="_blank"');
     expect(html).not.toContain('rel="noopener"');
   });
+
+  it("does not render empty slot wrappers when slots are unpopulated", async () => {
+    const html = await container.renderToString(SpTestimonial);
+
+    expect(html).not.toContain('class="sp-testimonial__quote"');
+    expect(html).not.toContain('class="sp-testimonial__author"');
+    expect(html).not.toContain('class="sp-testimonial__author-info"');
+    expect(html).not.toContain('class="sp-testimonial__author-name"');
+    expect(html).not.toContain('class="sp-testimonial__author-title"');
+  });
 });


### PR DESCRIPTION
This PR improves the `SpTestimonial` component by ensuring that its internal wrapper divs (for `quote`, `author`, `author-info`, etc.) are only rendered if the corresponding slots have content. This is achieved using `Astro.slots.has()`.

Key changes:
- Updated `SpTestimonial.astro` with conditional rendering logic for all named slots and their containers.
- Added a new test case in `tests/sp-testimonial.test.ts` to verify that empty slot wrappers are not rendered.
- Confirmed that all existing and new tests pass.

---
*PR created automatically by Jules for task [10110553537945520106](https://jules.google.com/task/10110553537945520106) started by @bradpotts*