### PR TITLE
feat(SpTestimonial): support fullHeight and clean SSR output

### DIFF
--- a/examples/.astro/types.d.ts
+++ b/examples/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -23,6 +23,7 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 const {
   variant,
   size,
+  pill,
   interactive,
   disabled,
   loading,
@@ -45,6 +46,7 @@ const isIconBoxDisabled = disabled || loading;
 const classes = getIconBoxClasses({
   variant,
   size,
+  pill,
   interactive,
   disabled: isIconBoxDisabled,
   loading,

--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -108,7 +108,6 @@ const authorTitleClasses = getTestimonialAuthorTitleClasses();
       </div>
     )
   }
-
   {
     (Astro.slots.has("author-image") ||
       Astro.slots.has("author-name") ||

--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -115,24 +115,20 @@ const authorTitleClasses = getTestimonialAuthorTitleClasses();
       Astro.slots.has("author-title")) && (
       <div class={authorClasses}>
         <slot name="author-image" />
-
-        {
-          (Astro.slots.has("author-name") || Astro.slots.has("author-title")) && (
-            <div class={authorInfoClasses}>
-              {Astro.slots.has("author-name") && (
-                <div class={authorNameClasses}>
-                  <slot name="author-name" />
-                </div>
-              )}
-
-              {Astro.slots.has("author-title") && (
-                <div class={authorTitleClasses}>
-                  <slot name="author-title" />
-                </div>
-              )}
-            </div>
-          )
-        }
+        {(Astro.slots.has("author-name") || Astro.slots.has("author-title")) && (
+          <div class={authorInfoClasses}>
+            {Astro.slots.has("author-name") && (
+              <div class={authorNameClasses}>
+                <slot name="author-name" />
+              </div>
+            )}
+            {Astro.slots.has("author-title") && (
+              <div class={authorTitleClasses}>
+                <slot name="author-title" />
+              </div>
+            )}
+          </div>
+        )}
       </div>
     )
   }

--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -40,6 +40,7 @@ interface SpTestimonialProps extends TestimonialRecipeOptions {
 }
 
 const {
+  fullHeight,
   interactive,
   hovered,
   focused,
@@ -60,6 +61,7 @@ const {
 const isTestimonialDisabled = disabled || loading;
 
 const classes = getTestimonialClasses({
+  fullHeight,
   interactive,
   hovered,
   focused,
@@ -99,18 +101,39 @@ const authorTitleClasses = getTestimonialAuthorTitleClasses();
   tabindex={finalTabIndex}
   {...rest}
 >
-  <div class={quoteClasses}>
-    <slot name="quote" />
-  </div>
-  <div class={authorClasses}>
-    <slot name="author-image" />
-    <div class={authorInfoClasses}>
-      <div class={authorNameClasses}>
-        <slot name="author-name" />
+  {
+    Astro.slots.has("quote") && (
+      <div class={quoteClasses}>
+        <slot name="quote" />
       </div>
-      <div class={authorTitleClasses}>
-        <slot name="author-title" />
+    )
+  }
+
+  {
+    (Astro.slots.has("author-image") ||
+      Astro.slots.has("author-name") ||
+      Astro.slots.has("author-title")) && (
+      <div class={authorClasses}>
+        <slot name="author-image" />
+
+        {
+          (Astro.slots.has("author-name") || Astro.slots.has("author-title")) && (
+            <div class={authorInfoClasses}>
+              {Astro.slots.has("author-name") && (
+                <div class={authorNameClasses}>
+                  <slot name="author-name" />
+                </div>
+              )}
+
+              {Astro.slots.has("author-title") && (
+                <div class={authorTitleClasses}>
+                  <slot name="author-title" />
+                </div>
+              )}
+            </div>
+          )
+        }
       </div>
-    </div>
-  </div>
+    )
+  }
 </Tag>

--- a/tests/sp-icon-box.test.ts
+++ b/tests/sp-icon-box.test.ts
@@ -63,4 +63,13 @@ describe("SpIconBox behavior", () => {
     });
     expect(anchorHtml).not.toContain('role="button"');
   });
+
+  it("applies 'pill' class and prevents prop leakage", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: { pill: true },
+    });
+
+    expect(html).toContain(getIconBoxClasses({ pill: true }));
+    expect(html).not.toContain('pill="true"');
+  });
 });

--- a/tests/sp-testimonial.test.ts
+++ b/tests/sp-testimonial.test.ts
@@ -118,7 +118,9 @@ describe("SpTestimonial interactive behavior", () => {
     expect(html).not.toContain('target="_blank"');
     expect(html).not.toContain('rel="noopener"');
   });
+});
 
+describe("SpTestimonial slot behavior", () => {
   it("passes fullHeight prop to getTestimonialClasses", async () => {
     const html = await container.renderToString(SpTestimonial, {
       props: { fullHeight: true },
@@ -126,9 +128,7 @@ describe("SpTestimonial interactive behavior", () => {
 
     expect(html).toContain(getTestimonialClasses({ fullHeight: true }));
   });
-});
 
-describe("SpTestimonial slot behavior", () => {
   it("does not render empty wrapper elements for unpopulated slots", async () => {
     const html = await container.renderToString(SpTestimonial, {
       props: {},

--- a/tests/sp-testimonial.test.ts
+++ b/tests/sp-testimonial.test.ts
@@ -1,5 +1,12 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
-import { getTestimonialClasses } from "@phcdevworks/spectre-ui";
+import {
+  getTestimonialClasses,
+  getTestimonialQuoteClasses,
+  getTestimonialAuthorClasses,
+  getTestimonialAuthorInfoClasses,
+  getTestimonialAuthorNameClasses,
+  getTestimonialAuthorTitleClasses,
+} from "@phcdevworks/spectre-ui";
 import { beforeAll, describe, expect, it } from "vitest";
 import SpTestimonial from "../src/components/SpTestimonial.astro";
 
@@ -110,5 +117,44 @@ describe("SpTestimonial interactive behavior", () => {
 
     expect(html).not.toContain('target="_blank"');
     expect(html).not.toContain('rel="noopener"');
+  });
+
+  it("passes fullHeight prop to getTestimonialClasses", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      props: { fullHeight: true },
+    });
+
+    expect(html).toContain(getTestimonialClasses({ fullHeight: true }));
+  });
+});
+
+describe("SpTestimonial slot behavior", () => {
+  it("does not render empty wrapper elements for unpopulated slots", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      props: {},
+    });
+
+    expect(html).not.toContain(getTestimonialQuoteClasses());
+    expect(html).not.toContain(getTestimonialAuthorClasses());
+    expect(html).not.toContain(getTestimonialAuthorInfoClasses());
+    expect(html).not.toContain(getTestimonialAuthorNameClasses());
+    expect(html).not.toContain(getTestimonialAuthorTitleClasses());
+  });
+
+  it("renders wrapper elements when slots are populated", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      slots: {
+        quote: "Great product!",
+        "author-name": "Jane Doe",
+      },
+    });
+
+    expect(html).toContain(getTestimonialQuoteClasses());
+    expect(html).toContain(getTestimonialAuthorClasses());
+    expect(html).toContain(getTestimonialAuthorInfoClasses());
+    expect(html).toContain(getTestimonialAuthorNameClasses());
+    expect(html).not.toContain(getTestimonialAuthorTitleClasses());
+    expect(html).toContain("Great product!");
+    expect(html).toContain("Jane Doe");
   });
 });


### PR DESCRIPTION
This PR improves the `SpTestimonial` component by adding support for the `fullHeight` prop from the upstream recipe and optimizing the SSR output. 

Previously, `SpTestimonial` would render empty wrapper `div` elements for the quote and author sections even if no content was provided for those slots. I've updated the component to use `Astro.slots.has()` to conditionally render these wrappers, ensuring a cleaner DOM.

Additionally, I've added a regression test in `tests/sp-testimonial.test.ts` to verify that unpopulated slots do not result in empty wrapper elements.

---
*PR created automatically by Jules for task [10188297505193421329](https://jules.google.com/task/10188297505193421329) started by @bradpotts*