### PR TITLE
Add fullHeight prop passthrough to SpPricingCard

### DIFF
--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -40,6 +40,7 @@ interface SpPricingCardProps extends PricingCardRecipeOptions {
 
 const {
   featured,
+  fullHeight,
   interactive,
   disabled,
   loading,
@@ -61,6 +62,7 @@ const isPricingCardDisabled = disabled || loading;
 
 const classes = getPricingCardClasses({
   featured,
+  fullHeight,
   interactive,
   disabled: isPricingCardDisabled,
   loading,

--- a/tests/sp-pricing-card.test.ts
+++ b/tests/sp-pricing-card.test.ts
@@ -74,6 +74,16 @@ describe("SpPricingCard behavior", () => {
     expect(html).not.toContain('active="true"');
   });
 
+  it("passes fullHeight to recipe and does not leak it to DOM", async () => {
+    const props = {
+      fullHeight: true,
+    };
+    const html = await container.renderToString(SpPricingCard, { props });
+
+    expect(html).toContain(getPricingCardClasses(props));
+    expect(html).not.toContain('fullHeight="true"');
+  });
+
   describe("slot behavior", () => {
     it("does not render empty wrapper divs when slots are not provided", async () => {
       const html = await container.renderToString(SpPricingCard, {


### PR DESCRIPTION
The `SpPricingCard` component was missing support for the `fullHeight` prop defined in its upstream recipe (`PricingCardRecipeOptions`). This change adds `fullHeight` to the prop destructuring and passes it to the `getPricingCardClasses` function.

Key changes:
- Updated `src/components/SpPricingCard.astro` to handle `fullHeight`.
- Added a regression test in `tests/sp-pricing-card.test.ts` to verify the fix.
- Verified that the change prevents attribute leakage to the DOM.

---
*PR created automatically by Jules for task [2889097789095550763](https://jules.google.com/task/2889097789095550763) started by @bradpotts*