### PR TITLE
Conditionally render default slot wrapper in SpRating

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -114,7 +114,11 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
       ))
     }
   </div>
-  <div class={textClasses}>
-    <slot />
-  </div>
+  {
+    Astro.slots.has("default") && (
+      <div class={textClasses}>
+        <slot />
+      </div>
+    )
+  }
 </Tag>

--- a/tests/sp-rating.test.ts
+++ b/tests/sp-rating.test.ts
@@ -85,3 +85,23 @@ describe("SpRating interactive behavior", () => {
     expect(classHovered).toBeDefined();
   });
 });
+
+describe("SpRating SSR optimization", () => {
+  it("does not render the text container when the default slot is empty", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { value: 4 },
+    });
+
+    expect(html).not.toContain('sp-rating-text');
+  });
+
+  it("renders the text container when the default slot has content", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { value: 4 },
+      slots: { default: "4.0 / 5.0" },
+    });
+
+    expect(html).toContain('sp-rating-text');
+    expect(html).toContain("4.0 / 5.0");
+  });
+});


### PR DESCRIPTION
Conditionally render the default slot wrapper div in `SpRating.astro` to improve SSR output by omitting empty markup when the slot is unused. Added corresponding tests to verify the behavior.

---
*PR created automatically by Jules for task [2648902434296947055](https://jules.google.com/task/2648902434296947055) started by @bradpotts*