### PR TITLE
Conditionally render SpRating default slot wrapper

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -114,7 +114,11 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
       ))
     }
   </div>
-  <div class={textClasses}>
-    <slot />
-  </div>
+  {
+    Astro.slots.has("default") && (
+      <div class={textClasses}>
+        <slot />
+      </div>
+    )
+  }
 </Tag>

--- a/tests/sp-rating.test.ts
+++ b/tests/sp-rating.test.ts
@@ -85,3 +85,23 @@ describe("SpRating interactive behavior", () => {
     expect(classHovered).toBeDefined();
   });
 });
+
+describe("SpRating slots", () => {
+  it("does not render the text wrapper div when the default slot is empty", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { value: 4 },
+    });
+
+    expect(html).not.toContain("sp-rating-text");
+  });
+
+  it("renders the text wrapper div when the default slot has content", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { value: 4 },
+      slots: { default: "Excellent service!" },
+    });
+
+    expect(html).toContain("sp-rating-text");
+    expect(html).toContain("Excellent service!");
+  });
+});


### PR DESCRIPTION
Implemented conditional rendering for the default slot wrapper in the `SpRating` component using `Astro.slots.has("default")`. This prevents the rendering of an empty `div` with the `sp-rating-text` class when no content is provided to the slot, ensuring cleaner and more deterministic SSR output. Added corresponding regression tests in `tests/sp-rating.test.ts` to verify the fix and prevent future regressions.

---
*PR created automatically by Jules for task [1763751279502414064](https://jules.google.com/task/1763751279502414064) started by @bradpotts*