### PR TITLE
Fix prop leakage in SpRating component

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -44,6 +44,8 @@ const {
   value = 0,
   max = 5,
   size,
+  pill,
+  fullWidth,
   interactive,
   disabled,
   loading,
@@ -65,6 +67,8 @@ const isRatingDisabled = disabled || loading;
 
 const classes = getRatingClasses({
   size,
+  pill,
+  fullWidth,
   interactive,
   disabled: isRatingDisabled,
   loading,

--- a/tests/sp-rating.test.ts
+++ b/tests/sp-rating.test.ts
@@ -84,6 +84,15 @@ describe("SpRating interactive behavior", () => {
     expect(classNormal).not.toBe(classHovered);
     expect(classHovered).toBeDefined();
   });
+
+  it("does not leak pill and fullWidth props to the DOM", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { pill: true, fullWidth: true },
+    });
+
+    expect(html).not.toContain('pill="true"');
+    expect(html).not.toContain('fullWidth="true"');
+  });
 });
 
 describe("SpRating slots", () => {


### PR DESCRIPTION
The `SpRating` component was leaking `pill` and `fullWidth` props into the DOM because they were not explicitly destructured from `Astro.props`. This PR fixes the leakage by destructuring these props and passing them to the styling recipe, following the pattern used in other components like `SpButton` and `SpIconBox`.

Key changes:
- Updated `src/components/SpRating.astro` to handle `pill` and `fullWidth`.
- Added a regression test in `tests/sp-rating.test.ts`.
- Verified the fix with `npm test` and `npm run typecheck`.

---
*PR created automatically by Jules for task [6818001340989063700](https://jules.google.com/task/6818001340989063700) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pill` and `fullWidth` styling options to the rating component for customizable layouts.

* **Tests**
  * Added test coverage to ensure new styling props don't leak into the DOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->