### PR TITLE
feat: add fullWidth support to SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -26,6 +26,7 @@ interface SpBadgeProps extends BadgeRecipeOptions {
 const {
   variant,
   size,
+  fullWidth,
   interactive,
   disabled,
   loading,
@@ -49,6 +50,7 @@ const isBadgeDisabled = disabled || loading;
 const classes = getBadgeClasses({
   variant,
   size,
+  fullWidth,
   interactive,
   disabled: isBadgeDisabled,
   loading,

--- a/tests/sp-badge.test.ts
+++ b/tests/sp-badge.test.ts
@@ -28,6 +28,16 @@ describe("SpBadge class and prop behavior", () => {
     expect(html).not.toContain('active="true"');
     expect(html).not.toContain('active="active"');
   });
+
+  it("applies fullWidth class and does not leak the prop to DOM", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: { fullWidth: true },
+    });
+
+    expect(html).toContain("sp-badge--full");
+    expect(html).not.toContain('fullWidth="true"');
+    expect(html).not.toContain('fullWidth="fullWidth"');
+  });
 });
 
 describe("SpBadge tabindex guarding", () => {


### PR DESCRIPTION
This change adds support for the `fullWidth` prop in the `SpBadge` component. The prop is now correctly destructured and passed to the `getBadgeClasses` styling recipe, ensuring the `sp-badge--full` class is applied when enabled. The prop is also excluded from the `...rest` spread to prevent it from leaking as a non-standard attribute in the rendered HTML. A regression test has been added to `tests/sp-badge.test.ts` to verify the class application and lack of attribute leakage.

---
*PR created automatically by Jules for task [2372803490864270830](https://jules.google.com/task/2372803490864270830) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `fullWidth` property on the badge component to properly apply full-width styling. The property is now correctly processed and rendered as intended.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->