### PR TITLE
Add fullWidth prop support to SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -26,6 +26,7 @@ interface SpBadgeProps extends BadgeRecipeOptions {
 const {
   variant,
   size,
+  fullWidth,
   interactive,
   disabled,
   loading,
@@ -49,6 +50,7 @@ const isBadgeDisabled = disabled || loading;
 const classes = getBadgeClasses({
   variant,
   size,
+  fullWidth,
   interactive,
   disabled: isBadgeDisabled,
   loading,

--- a/tests/sp-badge.test.ts
+++ b/tests/sp-badge.test.ts
@@ -28,6 +28,16 @@ describe("SpBadge class and prop behavior", () => {
     expect(html).not.toContain('active="true"');
     expect(html).not.toContain('active="active"');
   });
+
+  it("applies fullWidth class and does not leak the prop to DOM", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: { fullWidth: true },
+    });
+
+    expect(html).toContain("sp-badge--full");
+    expect(html).not.toContain('fullWidth="true"');
+    expect(html).not.toContain('fullWidth="fullWidth"');
+  });
 });
 
 describe("SpBadge tabindex guarding", () => {


### PR DESCRIPTION
This PR adds support for the `fullWidth` prop to the `SpBadge` component in the Astro adapter. 

Previously, the `fullWidth` prop was not being destructured, which meant:
1. The `sp-badge--full` class was not applied even if the prop was provided.
2. The prop would leak into the rendered HTML as a non-standard attribute.

The change aligns `SpBadge` with the upstream `@phcdevworks/spectre-ui` contract and improves DOM cleanliness.

Verification:
- `npm run build` & `npm run typecheck` passed.
- Added a new test in `tests/sp-badge.test.ts` to confirm `sp-badge--full` is rendered and `fullWidth` attribute is absent.
- All existing tests passed.

---
*PR created automatically by Jules for task [12940487100016525965](https://jules.google.com/task/12940487100016525965) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Badge component now supports a full width styling option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->