### PR TITLE
Improve SpInput accessibility and state synchronization

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -21,12 +21,13 @@ const {
   focused,
   hovered,
   active,
-  "aria-describedby": userDescribedBy,
-  "aria-invalid": userAriaInvalid,
+  "aria-describedby": ariaDescribedby,
+  "aria-invalid": ariaInvalid,
   ...rest
 } = Astro.props as SpInputProps;
 
 const isInputDisabled = disabled || state === "disabled" || loading;
+const isInputError = Boolean(errorMessage) || state === "error";
 
 const { inputId, helperId, errorId, describedBy } =
   resolveSpInputAccessibility({
@@ -34,20 +35,19 @@ const { inputId, helperId, errorId, describedBy } =
     label,
     helperText,
     errorMessage,
-    userDescribedBy,
+    "aria-describedby": ariaDescribedby,
   });
 
-const finalState =
-  loading
-    ? "loading"
-    : isInputDisabled
-      ? "disabled"
-      : errorMessage || state === "error"
-        ? "error"
-        : state;
+const effectiveState = loading
+  ? "loading"
+  : isInputDisabled
+    ? "disabled"
+    : isInputError
+      ? "error"
+      : state;
 
 const classes = getInputClasses({
-  state: finalState,
+  state: effectiveState,
   size,
   fullWidth,
   pill,
@@ -56,13 +56,6 @@ const classes = getInputClasses({
   active,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
-
-const finalAriaInvalid =
-  userAriaInvalid !== undefined
-    ? String(userAriaInvalid)
-    : finalState === "error"
-      ? "true"
-      : undefined;
 ---
 
 <Tag class="sp-input-wrapper">
@@ -77,7 +70,7 @@ const finalAriaInvalid =
   <input
     id={inputId}
     class={finalClass}
-    aria-invalid={finalAriaInvalid}
+    aria-invalid={ariaInvalid ?? (effectiveState === "error" ? "true" : undefined)}
     aria-describedby={describedBy}
     disabled={isInputDisabled}
     aria-disabled={isInputDisabled ? "true" : undefined}

--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -21,10 +21,13 @@ const {
   focused,
   hovered,
   active,
+  "aria-describedby": ariaDescribedby,
+  "aria-invalid": ariaInvalid,
   ...rest
 } = Astro.props as SpInputProps;
 
 const isInputDisabled = disabled || state === "disabled" || loading;
+const isInputError = Boolean(errorMessage) || state === "error";
 
 const { inputId, helperId, errorId, describedBy } =
   resolveSpInputAccessibility({
@@ -32,10 +35,19 @@ const { inputId, helperId, errorId, describedBy } =
     label,
     helperText,
     errorMessage,
+    "aria-describedby": ariaDescribedby,
   });
 
+const effectiveState = loading
+  ? "loading"
+  : isInputDisabled
+    ? "disabled"
+    : isInputError
+      ? "error"
+      : state;
+
 const classes = getInputClasses({
-  state: loading ? "loading" : isInputDisabled ? "disabled" : state,
+  state: effectiveState,
   size,
   fullWidth,
   pill,
@@ -58,7 +70,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
   <input
     id={inputId}
     class={finalClass}
-    aria-invalid={state === "error" ? "true" : undefined}
+    aria-invalid={ariaInvalid ?? (isInputError ? "true" : undefined)}
     aria-describedby={describedBy}
     disabled={isInputDisabled}
     aria-disabled={isInputDisabled ? "true" : undefined}

--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -38,10 +38,13 @@ const { inputId, helperId, errorId, describedBy } =
   });
 
 const finalState =
-  loading ? "loading" :
-  isInputDisabled ? "disabled" :
-  (errorMessage || state === "error") ? "error" :
-  state;
+  loading
+    ? "loading"
+    : isInputDisabled
+      ? "disabled"
+      : errorMessage || state === "error"
+        ? "error"
+        : state;
 
 const classes = getInputClasses({
   state: finalState,

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -19,6 +19,8 @@ interface SpInputBaseProps extends InputRecipeOptions {
   focused?: boolean;
   hovered?: boolean;
   active?: boolean;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean | "true" | "false" | "grammar" | "spelling";
   [key: string]: unknown;
 }
 
@@ -44,7 +46,11 @@ export function resolveSpInputAccessibility({
   label,
   helperText,
   errorMessage,
-}: Pick<SpInputProps, "id" | "label" | "helperText" | "errorMessage">) {
+  "aria-describedby": ariaDescribedby,
+}: Pick<
+  SpInputProps,
+  "id" | "label" | "helperText" | "errorMessage" | "aria-describedby"
+>) {
   const requiresStableId = Boolean(label || helperText || errorMessage);
 
   if (requiresStableId && !id) {
@@ -56,10 +62,16 @@ export function resolveSpInputAccessibility({
   const helperId = id && helperText ? `${id}-helper` : undefined;
   const errorId = id && errorMessage ? `${id}-error` : undefined;
 
+  // Follow the rendering logic in SpInput.astro: errorMessage suppresses helperText.
+  const activeGeneratedId = errorId ?? helperId;
+  const mergedDescribedBy = [ariaDescribedby, activeGeneratedId]
+    .filter(Boolean)
+    .join(" ");
+
   return {
     inputId: id,
     helperId,
     errorId,
-    describedBy: errorId ?? helperId,
+    describedBy: mergedDescribedBy || undefined,
   };
 }

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -46,10 +46,11 @@ export function resolveSpInputAccessibility({
   label,
   helperText,
   errorMessage,
-  userDescribedBy,
-}: Pick<SpInputProps, "id" | "label" | "helperText" | "errorMessage"> & {
-  userDescribedBy?: string;
-}) {
+  "aria-describedby": ariaDescribedby,
+}: Pick<
+  SpInputProps,
+  "id" | "label" | "helperText" | "errorMessage" | "aria-describedby"
+>) {
   const requiresStableId = Boolean(label || helperText || errorMessage);
 
   if (requiresStableId && !id) {
@@ -61,8 +62,9 @@ export function resolveSpInputAccessibility({
   const helperId = id && helperText ? `${id}-helper` : undefined;
   const errorId = id && errorMessage ? `${id}-error` : undefined;
 
-  const internalDescribedBy = errorId ?? helperId;
-  const describedBy = [userDescribedBy, internalDescribedBy]
+  // Follow the rendering logic in SpInput.astro: errorMessage suppresses helperText.
+  const activeGeneratedId = errorId ?? helperId;
+  const mergedDescribedBy = [ariaDescribedby, activeGeneratedId]
     .filter(Boolean)
     .join(" ");
 
@@ -70,6 +72,6 @@ export function resolveSpInputAccessibility({
     inputId: id,
     helperId,
     errorId,
-    describedBy: describedBy || undefined,
+    describedBy: mergedDescribedBy || undefined,
   };
 }

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -62,7 +62,7 @@ export function resolveSpInputAccessibility({
   const errorId = id && errorMessage ? `${id}-error` : undefined;
 
   const internalDescribedBy = errorId ?? helperId;
-  const describedBy = [internalDescribedBy, userDescribedBy]
+  const describedBy = [userDescribedBy, internalDescribedBy]
     .filter(Boolean)
     .join(" ");
 

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -26,4 +26,65 @@ describe("SpInput state behavior", () => {
     expect(html).not.toMatch(/<input[^>]*\shovered\b/);
     expect(html).not.toMatch(/<input[^>]*\sactive\b/);
   });
+
+  it("automatically sets visual error state and aria-invalid when errorMessage is present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { id: "test-input", errorMessage: "Invalid input" } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputClasses({ state: "error" }));
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain('id="test-input-error"');
+    expect(html).toContain('aria-describedby="test-input-error"');
+  });
+
+  it("merges user-provided aria-describedby with generated IDs", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        id: "test-input",
+        helperText: "Help",
+        "aria-describedby": "external-id",
+      } as SpInputProps,
+    });
+
+    expect(html).toContain('aria-describedby="external-id test-input-helper"');
+  });
+
+  it("allows overriding aria-invalid even when errorMessage is present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        id: "test-input",
+        errorMessage: "Error",
+        "aria-invalid": "grammar",
+      } as SpInputProps,
+    });
+
+    expect(html).toContain('aria-invalid="grammar"');
+    expect(html).not.toContain('aria-invalid="true"');
+  });
+
+  it("prioritizes errorId over helperId in aria-describedby when both are present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        id: "test-input",
+        helperText: "Help",
+        errorMessage: "Error",
+      } as SpInputProps,
+    });
+
+    // When error is present, only errorId should be in aria-describedby
+    // Actually, based on my implementation: mergedDescribedBy = [ariaDescribedby, ...generatedIds].join(" ");
+    // where generatedIds = [errorId, helperId].filter(Boolean)
+    // So it will be "test-input-error test-input-helper"
+    // Wait, let's re-check the previous implementation: describedBy: errorId ?? helperId
+    // My new implementation merges them. Is this desired?
+    // Usually it's better to have both if both are visible.
+    // But in SpInput.astro:
+    // { helperText && !errorMessage && ( ... ) }
+    // It only renders helperText IF NO errorMessage.
+    // So my resolveSpInputAccessibility should probably match that logic or the describedBy should only include what's rendered.
+
+    expect(html).toContain('aria-describedby="test-input-error"');
+    expect(html).not.toContain("test-input-helper");
+  });
 });

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -38,7 +38,7 @@ describe("SpInput accessibility and error state synchronization", () => {
       } as SpInputProps,
     });
 
-    expect(html).toContain('aria-describedby="test-input-helper custom-desc"');
+    expect(html).toContain('aria-describedby="custom-desc test-input-helper"');
   });
 
   it("prioritizes user-provided aria-invalid over internal state", async () => {

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   container = await AstroContainer.create();
 });
 
-describe("SpInput state behavior", () => {
+describe("SpInput behavior", () => {
   it("passes hovered, focused, and active states to the recipe without leaking them to DOM", async () => {
     const html = await container.renderToString(SpInput, {
       props: { hovered: true, focused: true, active: true } as SpInputProps,
@@ -26,57 +26,65 @@ describe("SpInput state behavior", () => {
     expect(html).not.toMatch(/<input[^>]*\shovered\b/);
     expect(html).not.toMatch(/<input[^>]*\sactive\b/);
   });
-});
 
-describe("SpInput accessibility and error state synchronization", () => {
-  it("merges custom aria-describedby with internal helperText ID", async () => {
+  it("automatically sets visual error state and aria-invalid when errorMessage is present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { id: "test-input", errorMessage: "Invalid input" } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputClasses({ state: "error" }));
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain('id="test-input-error"');
+    expect(html).toContain('aria-describedby="test-input-error"');
+  });
+
+  it("merges user-provided aria-describedby with generated IDs", async () => {
     const html = await container.renderToString(SpInput, {
       props: {
         id: "test-input",
-        helperText: "Helpful text",
-        "aria-describedby": "custom-desc",
+        helperText: "Help",
+        "aria-describedby": "external-id",
       } as SpInputProps,
     });
 
-    expect(html).toContain('aria-describedby="custom-desc test-input-helper"');
+    expect(html).toContain('aria-describedby="external-id test-input-helper"');
+  });
+
+  it("allows overriding aria-invalid even when errorMessage is present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        id: "test-input",
+        errorMessage: "Error",
+        "aria-invalid": "grammar",
+      } as SpInputProps,
+    });
+
+    expect(html).toContain('aria-invalid="grammar"');
+    expect(html).not.toContain('aria-invalid="true"');
+  });
+
+  it("prioritizes errorId over helperId in aria-describedby when both are present", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: {
+        id: "test-input",
+        helperText: "Help",
+        errorMessage: "Error",
+      } as SpInputProps,
+    });
+
+    expect(html).toContain('aria-describedby="test-input-error"');
+    expect(html).not.toContain("test-input-helper");
   });
 
   it("prioritizes user-provided aria-invalid over internal state", async () => {
     const html = await container.renderToString(SpInput, {
       props: {
         id: "test-input",
-        "aria-invalid": "grammar",
-        state: "error",
+        "aria-invalid": "false",
+        state: "error"
       } as SpInputProps,
     });
 
-    expect(html).toContain('aria-invalid="grammar"');
-  });
-
-  it("automatically sets aria-invalid and applies error state when errorMessage is provided", async () => {
-    const html = await container.renderToString(SpInput, {
-      props: {
-        id: "test-input",
-        errorMessage: "Something went wrong",
-      } as SpInputProps,
-    });
-
-    expect(html).toContain('aria-invalid="true"');
-    expect(html).toContain(getInputClasses({ state: "error" }));
-    expect(html).toContain('id="test-input-error"');
-    expect(html).toContain('aria-describedby="test-input-error"');
-  });
-
-  it("omits helper text IDs from aria-describedby when an error message is rendered", async () => {
-    const html = await container.renderToString(SpInput, {
-      props: {
-        id: "test-input",
-        helperText: "Helpful text",
-        errorMessage: "Something went wrong",
-      } as SpInputProps,
-    });
-
-    expect(html).toContain('aria-describedby="test-input-error"');
-    expect(html).not.toContain("test-input-helper");
+    expect(html).toContain('aria-invalid="false"');
   });
 });


### PR DESCRIPTION
Improved the \`SpInput\` component's accessibility and state handling. Key changes include:
- Visual state and \`aria-invalid\` now automatically reflect the presence of \`errorMessage\`.
- \`aria-describedby\` now merges user-provided IDs with internal IDs instead of overriding them.
- Consumers can now explicitly set \`aria-invalid\` to specific values (e.g., 'grammar').
- Full test coverage for these improvements has been added.

---
*PR created automatically by Jules for task [7388541989496431424](https://jules.google.com/task/7388541989496431424) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input component now recognizes "grammar" and "spelling" as distinct accessibility states and uses an effective state calculation that prioritizes loading/disabled and error conditions.
* **Bug Fixes**
  * Improved handling of helper text vs. error messages so assistive technologies receive the correct referenced IDs and ordering.
  * Explicit aria-invalid values now take precedence over derived error-state values.
* **Tests**
  * Expanded accessibility tests covering aria-describedby ordering and error-state interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/88)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->