### PR TITLE
Improve SpInput polymorphism and accessibility

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -88,7 +88,7 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
 
   {
     errorMessage && (
-      <p class="sp-error-message" id={errorId}>
+      <p class="sp-error-message" id={errorId} aria-live="polite">
         {errorMessage}
       </p>
     )

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -9,7 +9,9 @@ type SpInputElement =
   | "footer"
   | "main"
   | "form"
-  | "fieldset";
+  | "fieldset"
+  | "li"
+  | "nav";
 
 interface SpInputBaseProps extends InputRecipeOptions {
   as?: SpInputElement;

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -87,4 +87,25 @@ describe("SpInput behavior", () => {
 
     expect(html).toContain('aria-invalid="false"');
   });
+
+  it("applies aria-live='polite' to the error message", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { id: "test-input", errorMessage: "Error occurred" } as SpInputProps,
+    });
+
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('class="sp-error-message"');
+  });
+
+  it("supports 'li' and 'nav' as wrapper tags", async () => {
+    const htmlLi = await container.renderToString(SpInput, {
+      props: { as: "li" } as SpInputProps,
+    });
+    expect(htmlLi).toContain("<li");
+
+    const htmlNav = await container.renderToString(SpInput, {
+      props: { as: "nav" } as SpInputProps,
+    });
+    expect(htmlNav).toContain("<nav");
+  });
 });


### PR DESCRIPTION
This change expands the allowed wrapper tags for SpInput to include 'li' and 'nav', and adds 'aria-live="polite"' to the error message for better screen reader support.

---
*PR created automatically by Jules for task [5017817304266115683](https://jules.google.com/task/5017817304266115683) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Error messages now announce to screen readers, improving usability for assistive technology users.

* **New Features**
  * Input component now supports `<li>` and `<nav>` as wrapper elements for more flexible layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->