### PR TITLE
Improve SpRating accessibility and HTML validity

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -104,10 +104,13 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
   aria-disabled={isRatingDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-valuenow={value}
+  aria-valuemin={0}
+  aria-valuemax={max}
   tabindex={finalTabIndex}
   {...rest}
 >
-  <div class={starsClasses} aria-hidden="true">
+  <span class={starsClasses} aria-hidden="true">
     {
       stars.map((isFilled) => (
         <span class={getRatingStarClasses(isFilled)}>
@@ -117,12 +120,12 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
         </span>
       ))
     }
-  </div>
+  </span>
   {
     Astro.slots.has("default") && (
-      <div class={textClasses}>
+      <span class={textClasses}>
         <slot />
-      </div>
+      </span>
     )
   }
 </Tag>

--- a/tests/sp-rating.test.ts
+++ b/tests/sp-rating.test.ts
@@ -9,12 +9,15 @@ beforeAll(async () => {
 });
 
 describe("SpRating accessibility", () => {
-  it("renders aria-label on the root element", async () => {
+  it("renders aria-label and ARIA value attributes on the root element", async () => {
     const html = await container.renderToString(SpRating, {
-      props: { "aria-label": "User rating: 4 out of 5 stars", value: 4 },
+      props: { "aria-label": "User rating: 4 out of 5 stars", value: 4, max: 5 },
     });
 
     expect(html).toContain('aria-label="User rating: 4 out of 5 stars"');
+    expect(html).toContain('aria-valuenow="4"');
+    expect(html).toContain('aria-valuemin="0"');
+    expect(html).toContain('aria-valuemax="5"');
   });
 
   it("hides the stars container from screen readers", async () => {
@@ -170,8 +173,8 @@ describe("SpRating pill and fullWidth prop forwarding", () => {
   });
 });
 
-describe("SpRating slots", () => {
-  it("does not render the text wrapper div when the default slot is empty", async () => {
+describe("SpRating slots and structure", () => {
+  it("does not render the text wrapper span when the default slot is empty", async () => {
     const html = await container.renderToString(SpRating, {
       props: { value: 4 },
     });
@@ -179,7 +182,7 @@ describe("SpRating slots", () => {
     expect(html).not.toContain("sp-rating-text");
   });
 
-  it("renders the text wrapper div when the default slot has content", async () => {
+  it("renders the text wrapper span when the default slot has content", async () => {
     const html = await container.renderToString(SpRating, {
       props: { value: 4 },
       slots: { default: "Excellent service!" },
@@ -187,5 +190,15 @@ describe("SpRating slots", () => {
 
     expect(html).toContain("sp-rating-text");
     expect(html).toContain("Excellent service!");
+  });
+
+  it("has valid HTML when rendered as a span (no div inside span)", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { as: "span", value: 3 },
+      slots: { default: "Text" },
+    });
+
+    expect(html).toContain("<span");
+    expect(html).not.toContain("<div");
   });
 });


### PR DESCRIPTION
This PR improves the `SpRating` component by adding missing ARIA value attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`) and fixing an HTML validity issue where `div` elements were nested inside the component even when it was rendered as a `span`.

These changes are purely structural and accessibility-focused, adhering to the Astro adapter's responsibilities and avoiding any CSS modifications.

---
*PR created automatically by Jules for task [15930893572249110198](https://jules.google.com/task/15930893572249110198) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rating component accessibility with comprehensive ARIA attributes for enhanced screen reader support.
  * Enhanced HTML structure for semantic validity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->