### PR TITLE
Improve SpInput prop forwarding and accessibility

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -21,6 +21,14 @@ const {
   focused,
   hovered,
   active,
+  name,
+  value,
+  placeholder,
+  required,
+  readonly,
+  type,
+  autocomplete,
+  "aria-label": ariaLabel,
   "aria-describedby": ariaDescribedby,
   "aria-invalid": ariaInvalid,
   ...rest
@@ -70,8 +78,17 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
   <input
     id={inputId}
     class={finalClass}
+    name={name}
+    value={value}
+    placeholder={placeholder}
+    required={required}
+    readonly={readonly}
+    type={type}
+    autocomplete={autocomplete}
+    aria-label={ariaLabel}
     aria-invalid={ariaInvalid ?? (effectiveState === "error" ? "true" : undefined)}
     aria-describedby={describedBy}
+    aria-required={required ? "true" : undefined}
     disabled={isInputDisabled}
     aria-disabled={isInputDisabled ? "true" : undefined}
     aria-busy={loading ? "true" : undefined}

--- a/src/components/sp-input.shared.ts
+++ b/src/components/sp-input.shared.ts
@@ -21,6 +21,14 @@ interface SpInputBaseProps extends InputRecipeOptions {
   focused?: boolean;
   hovered?: boolean;
   active?: boolean;
+  name?: string;
+  value?: string | number;
+  placeholder?: string;
+  required?: boolean;
+  readonly?: boolean;
+  type?: string;
+  autocomplete?: string;
+  "aria-label"?: string;
   "aria-describedby"?: string;
   "aria-invalid"?: boolean | "true" | "false" | "grammar" | "spelling";
   [key: string]: unknown;

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -110,4 +110,36 @@ describe("SpInput behavior", () => {
     });
     expect(htmlNav).toContain("<nav");
   });
+
+  it("forwards standard HTML input attributes correctly", async () => {
+    const props: SpInputProps = {
+      name: "test-name",
+      value: "test-value",
+      placeholder: "test-placeholder",
+      type: "email",
+      autocomplete: "email",
+      "aria-label": "test-label",
+      required: true,
+      readonly: true,
+    };
+
+    const html = await container.renderToString(SpInput, { props });
+
+    expect(html).toContain('name="test-name"');
+    expect(html).toContain('value="test-value"');
+    expect(html).toContain('placeholder="test-placeholder"');
+    expect(html).toContain('type="email"');
+    expect(html).toContain('autocomplete="email"');
+    expect(html).toContain('aria-label="test-label"');
+    expect(html).toMatch(/<input[^>]*\srequired\b/);
+    expect(html).toMatch(/<input[^>]*\sreadonly\b/);
+    expect(html).toContain('aria-required="true"');
+  });
+
+  it("does not set aria-required when required is false or undefined", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { required: false } as SpInputProps,
+    });
+    expect(html).not.toContain('aria-required="true"');
+  });
 });


### PR DESCRIPTION
This change improves the SpInput component by explicitly handling and forwarding standard HTML input attributes. This enhances the developer experience in TypeScript and ensures better accessibility by synchronizing the `required` prop with the `aria-required` attribute. The implementation remains thin and strictly focused on Astro adapter responsibilities.

---
*PR created automatically by Jules for task [12316834766022562301](https://jules.google.com/task/12316834766022562301) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input component now supports standard HTML input attributes (name, value, placeholder, type, autocomplete, required, readonly)
  * Enhanced accessibility with ARIA label, required, and described-by attributes

* **Tests**
  * Added test cases verifying attribute forwarding and ARIA behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->