### PR TITLE
Improve SpCard interactivity inference

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -58,10 +58,11 @@ const {
 } = Astro.props as SpCardProps;
 
 const isCardDisabled = disabled || loading;
+const isInteractive = interactive || Tag === "a" || Tag === "button";
 
 const classes = getCardClasses({
   variant,
-  interactive,
+  interactive: isInteractive,
   padded,
   fullHeight,
   disabled: isCardDisabled,
@@ -78,7 +79,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   href,
   type,
   tabindex,
-  interactive,
+  interactive: isInteractive,
 });
 ---
 
@@ -89,7 +90,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isCardDisabled ? true : undefined}
-  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
+  role={isInteractive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isCardDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/sp-card.test.ts
+++ b/tests/sp-card.test.ts
@@ -84,4 +84,22 @@ describe("SpCard accessibility and tabindex guarding", () => {
 
     expect(html).not.toContain('tabindex="-1"');
   });
+
+  it("automatically applies interactive classes when rendered as 'button'", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: { as: "button" },
+    });
+
+    const interactiveClasses = getCardClasses({ interactive: true });
+    expect(html).toContain(interactiveClasses);
+  });
+
+  it("automatically applies interactive classes when rendered as 'a'", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: { as: "a", href: "#" },
+    });
+
+    const interactiveClasses = getCardClasses({ interactive: true });
+    expect(html).toContain(interactiveClasses);
+  });
 });


### PR DESCRIPTION
Modified SpCard to automatically infer an interactive state when rendered as an anchor or a button. This ensures that cards rendered with these tags receive the appropriate styling and accessibility attributes without requiring an explicit 'interactive' prop. Updated tests with regression cases.

---
*PR created automatically by Jules for task [12849897241147905340](https://jules.google.com/task/12849897241147905340) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SpCard now automatically applies interactive styling and attributes based on the element type (button or link), improving consistency and reducing configuration errors.

* **Tests**
  * Added test coverage for interactive button and link component variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->