### PR TITLE
feat: automatic interactivity inference for SpBadge

### DIFF
--- a/examples/src/pages/primitives.astro
+++ b/examples/src/pages/primitives.astro
@@ -47,6 +47,15 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <SpBadge variant="primary" fullWidth>Full Width Badge</SpBadge>
         </div>
       </SpCard>
+
+      <SpCard variant="flat" class="sp-stack">
+        <h2>Badge Interactivity Inference</h2>
+        <div class="sp-hstack inline">
+          <SpBadge as="button" variant="primary" id="badge-button">As Button</SpBadge>
+          <SpBadge as="a" href="#" variant="success" id="badge-link">As Link</SpBadge>
+          <SpBadge as="span" variant="warning" id="badge-span">As Span (Non-interactive)</SpBadge>
+        </div>
+      </SpCard>
     </section>
 
     <section class="grid">

--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -46,12 +46,13 @@ const {
 } = Astro.props as SpBadgeProps;
 
 const isBadgeDisabled = disabled || loading;
+const isInteractive = interactive || Tag === "a" || Tag === "button";
 
 const classes = getBadgeClasses({
   variant,
   size,
   fullWidth,
-  interactive,
+  interactive: isInteractive,
   disabled: isBadgeDisabled,
   loading,
   hovered,
@@ -66,7 +67,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   href,
   type,
   tabindex,
-  interactive,
+  interactive: isInteractive,
 });
 ---
 
@@ -77,7 +78,7 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
   disabled={Tag === "button" && isBadgeDisabled ? true : undefined}
-  role={interactive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
+  role={isInteractive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isBadgeDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -219,7 +219,7 @@ describe("SSR rendering", () => {
       },
     });
 
-    expect(html).toContain(getBadgeClasses({ variant: "primary", size: "sm", loading: true, disabled: true }));
+    expect(html).toContain(getBadgeClasses({ variant: "primary", size: "sm", loading: true, disabled: true, interactive: true }));
     expect(html).toContain('aria-disabled="true"');
     expect(html).toContain('aria-busy="true"');
     expect(html).toContain('tabindex="-1"');

--- a/tests/sp-badge.test.ts
+++ b/tests/sp-badge.test.ts
@@ -1,4 +1,5 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { getBadgeClasses } from "@phcdevworks/spectre-ui";
 import { beforeAll, describe, expect, it } from "vitest";
 import SpBadge from "../src/components/SpBadge.astro";
 
@@ -40,7 +41,7 @@ describe("SpBadge class and prop behavior", () => {
   });
 });
 
-describe("SpBadge tabindex guarding", () => {
+describe("SpBadge interactivity and tabindex guarding", () => {
   it("applies tabindex=0 when interactive on a non-native element", async () => {
     const html = await container.renderToString(SpBadge, {
       props: { interactive: true, as: "div" },
@@ -55,5 +56,23 @@ describe("SpBadge tabindex guarding", () => {
     });
 
     expect(html).toContain('tabindex="-1"');
+  });
+
+  it("automatically applies interactive classes when rendered as 'button'", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: { as: "button" },
+    });
+
+    const interactiveClasses = getBadgeClasses({ interactive: true });
+    expect(html).toContain(interactiveClasses);
+  });
+
+  it("automatically applies interactive classes when rendered as 'a'", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: { as: "a", href: "#" },
+    });
+
+    const interactiveClasses = getBadgeClasses({ interactive: true });
+    expect(html).toContain(interactiveClasses);
   });
 });


### PR DESCRIPTION
Implemented "Smart Interactivity Inference" for the `SpBadge` component. The component now automatically applies interactive styling and accessibility attributes when rendered as an `<a>` or `<button>` tag, even if the `interactive` prop is not explicitly provided. This improves developer ergonomics and ensures accessibility by default for polymorphic interactive usage. Verified via Vitest and Playwright.

---
*PR created automatically by Jules for task [3485717446897680577](https://jules.google.com/task/3485717446897680577) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Badges now automatically recognize when rendered as interactive elements (button or link) and apply appropriate interactive styling without requiring additional configuration.
  * Added example demonstrations showing badge rendering with button, link, and non-interactive states.

* **Tests**
  * Expanded test coverage to verify badge interactivity detection and proper styling application for interactive element types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->