### PR TITLE
Add fullWidth prop support to SpIconBox

### DIFF
--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -16,6 +16,7 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
   type?: "button" | "submit" | "reset";
   tabindex?: number;
   "aria-label"?: string;
+  fullWidth?: boolean;
 
   [key: string]: unknown;
 }
@@ -24,6 +25,7 @@ const {
   variant,
   size,
   pill,
+  fullWidth,
   interactive,
   disabled,
   loading,
@@ -48,6 +50,7 @@ const classes = getIconBoxClasses({
   variant,
   size,
   pill,
+  fullWidth,
   interactive: isInteractive,
   disabled: isIconBoxDisabled,
   loading,

--- a/tests/sp-icon-box.test.ts
+++ b/tests/sp-icon-box.test.ts
@@ -88,4 +88,13 @@ describe("SpIconBox behavior", () => {
 
     expect(html).toContain("sp-iconbox--interactive");
   });
+
+  it("applies 'fullWidth' class and prevents prop leakage", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: { fullWidth: true },
+    });
+
+    expect(html).toContain("sp-iconbox--full");
+    expect(html).not.toContain('fullWidth="true"');
+  });
 });


### PR DESCRIPTION
Added `fullWidth` prop support to `SpIconBox.astro`, updated the component interface, and added regression tests to verify class application and prevent prop leakage.

---
*PR created automatically by Jules for task [7758656810031754752](https://jules.google.com/task/7758656810031754752) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpIconBox now supports full-width display styling with the new `fullWidth` prop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->