### PR TITLE
fix(spectre-ui-astro): ensure SpInput helper text and recipe correctly handle disabled and loading states

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -68,12 +68,14 @@ const classes = getInputClasses({
   focused,
   hovered,
   active,
+  disabled: isInputDisabled,
+  loading,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
 const wrapperClasses = getInputWrapperClasses();
 const labelClasses = getInputLabelClasses({ disabled: isInputDisabled });
-const helperTextClasses = getInputHelperTextClasses();
+const helperTextClasses = getInputHelperTextClasses({ disabled: isInputDisabled });
 const errorMessageClasses = getInputErrorMessageClasses();
 ---
 

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -155,4 +155,21 @@ describe("SpInput behavior", () => {
     });
     expect(html).not.toContain('aria-required="true"');
   });
+
+  it("applies disabled styling to helper text and input when disabled", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { id: "test-input", helperText: "Help", disabled: true } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputHelperTextClasses({ disabled: true }));
+    expect(html).toContain(getInputClasses({ state: "disabled", disabled: true }));
+  });
+
+  it("applies loading state to input recipe", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { loading: true } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputClasses({ state: "loading", loading: true, disabled: true }));
+  });
 });


### PR DESCRIPTION
This change updates the SpInput component to correctly pass the disabled and loading states to its styling recipes (getInputClasses and getInputHelperTextClasses). This ensures that the component visually and structurally reflects these states as intended by the upstream UI library. It also adds regression tests to verify this behavior.

---
*PR created automatically by Jules for task [648476340472907784](https://jules.google.com/task/648476340472907784) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpInput component now features improved styling for disabled and loading states with explicit state management.

* **Tests**
  * Added test coverage verifying correct styling application in disabled and loading states for the SpInput component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->