### PR TITLE
Fix SpTestimonial variant support and prop leakage

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -40,6 +40,7 @@ interface SpTestimonialProps extends TestimonialRecipeOptions {
 }
 
 const {
+  variant,
   fullHeight,
   interactive,
   hovered,
@@ -62,6 +63,7 @@ const isTestimonialDisabled = disabled || loading;
 const isInteractive = interactive || Tag === "a" || Tag === "button";
 
 const classes = getTestimonialClasses({
+  variant,
   fullHeight,
   interactive: isInteractive,
   hovered,

--- a/tests/sp-testimonial.test.ts
+++ b/tests/sp-testimonial.test.ts
@@ -73,6 +73,15 @@ describe("SpTestimonial SSR rendering", () => {
     expect(html).toContain("sp-testimonial--full");
     expect(html).not.toMatch(/\sfullHeight=["']/);
   });
+
+  it("applies variant prop and does not leak it to the DOM", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      props: { variant: "ghost" },
+    });
+
+    expect(html).toContain("sp-testimonial--ghost");
+    expect(html).not.toMatch(/\svariant=["']/);
+  });
 });
 
 describe("SpTestimonial slot rendering", () => {


### PR DESCRIPTION
This change fixes a concrete gap in the `SpTestimonial` component where the `variant` prop was not being utilized for styling and was leaking into the rendered HTML as a DOM attribute.

Key improvements:
- **Accessibility & Clean DOM**: Prevents the `variant` prop from leaking to the DOM by explicitly destructuring it from `Astro.props`.
- **Feature Parity**: Enables support for testimonial variants (e.g., `flat`, `outline`, `ghost`) by passing the prop to the upstream styling recipe.
- **Regression Testing**: Adds a new test case to ensure future changes do not re-introduce the leakage or break variant styling.

The change was verified using the full validation suite (`npm run check`) and visual DOM inspection via Playwright.

---
*PR created automatically by Jules for task [578990426105719228](https://jules.google.com/task/578990426105719228) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed testimonial component variant support to properly apply CSS styling based on the specified variant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->