### PR TITLE
Unify SpInput state prop with functional attributes

### DIFF
--- a/src/components/SpInput.astro
+++ b/src/components/SpInput.astro
@@ -40,7 +40,8 @@ const {
   ...rest
 } = Astro.props as SpInputProps;
 
-const isInputDisabled = disabled || state === "disabled" || loading;
+const isInputLoading = loading || state === "loading";
+const isInputDisabled = disabled || state === "disabled" || isInputLoading;
 const isInputError = Boolean(errorMessage) || state === "error";
 
 const { inputId, helperId, errorId, describedBy } =
@@ -52,7 +53,7 @@ const { inputId, helperId, errorId, describedBy } =
     "aria-describedby": ariaDescribedby,
   });
 
-const effectiveState = loading
+const effectiveState = isInputLoading
   ? "loading"
   : isInputDisabled
     ? "disabled"
@@ -69,7 +70,7 @@ const classes = getInputClasses({
   hovered,
   active,
   disabled: isInputDisabled,
-  loading,
+  loading: isInputLoading,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
@@ -104,7 +105,7 @@ const errorMessageClasses = getInputErrorMessageClasses();
     aria-required={required ? "true" : undefined}
     disabled={isInputDisabled}
     aria-disabled={isInputDisabled ? "true" : undefined}
-    aria-busy={loading ? "true" : undefined}
+    aria-busy={isInputLoading ? "true" : undefined}
     {...rest}
   />
 

--- a/tests/sp-input.test.ts
+++ b/tests/sp-input.test.ts
@@ -172,4 +172,30 @@ describe("SpInput behavior", () => {
 
     expect(html).toContain(getInputClasses({ state: "loading", loading: true, disabled: true }));
   });
+
+  it("treats state='loading' as functionally equivalent to loading=true", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { state: "loading", id: "loading-input", label: "Loading", helperText: "Waiting..." } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputClasses({ state: "loading", loading: true, disabled: true }));
+    expect(html).toContain("disabled");
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain(getInputLabelClasses({ disabled: true }));
+    expect(html).toContain(getInputHelperTextClasses({ disabled: true }));
+  });
+
+  it("treats state='disabled' as functionally equivalent to disabled=true", async () => {
+    const html = await container.renderToString(SpInput, {
+      props: { state: "disabled", id: "disabled-input", label: "Disabled", helperText: "Locked" } as SpInputProps,
+    });
+
+    expect(html).toContain(getInputClasses({ state: "disabled", disabled: true }));
+    expect(html).toContain("disabled");
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).not.toContain('aria-busy="true"');
+    expect(html).toContain(getInputLabelClasses({ disabled: true }));
+    expect(html).toContain(getInputHelperTextClasses({ disabled: true }));
+  });
 });


### PR DESCRIPTION
This change ensures that state="loading" and state="disabled" on SpInput correctly synchronize with the underlying <input> element's disabled attribute, aria-busy, and aria-disabled states, as well as sub-element styling (label and helper text). New regression tests verify these state enum behaviors.

---
*PR created automatically by Jules for task [4998758192382359929](https://jules.google.com/task/4998758192382359929) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input component now properly handles `state="loading"` and `state="disabled"`, ensuring consistent styling and accessibility features.

* **Tests**
  * Added test coverage for state equivalence behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->