### PR TITLE
Align spectre-tokens peer dependency with upstream v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "tag": "latest"
   },
   "peerDependencies": {
-    "@phcdevworks/spectre-tokens": "^2.5.0",
+    "@phcdevworks/spectre-tokens": "^2.6.0",
     "@phcdevworks/spectre-ui": "^1.5.0",
     "astro": "^6.1.3",
     "typescript": "^5.9 || ^6.0"


### PR DESCRIPTION
Aligned the `@phcdevworks/spectre-tokens` version in `peerDependencies` to `^2.6.0` to match the minimum requirement of `@phcdevworks/spectre-ui` v1.6.0. This ensures that consumers of the Astro adapter have a compatible version of design tokens as required by the upstream styling contract.

---
*PR created automatically by Jules for task [11337979893092156537](https://jules.google.com/task/11337979893092156537) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spectre Tokens package to version 2.6.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->