### PR TITLE
Add id and aria-describedby support to SpButton

### DIFF
--- a/src/components/SpButton.astro
+++ b/src/components/SpButton.astro
@@ -15,7 +15,9 @@ interface SpButtonProps extends ButtonRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
   [key: string]: unknown;
 }
 
@@ -37,7 +39,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpButtonProps;
 
@@ -74,11 +78,13 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
+  id={id}
   disabled={Tag === "button" && isDisabled ? true : undefined}
   role={Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   tabindex={finalTabIndex}
   {...rest}
 >

--- a/tests/sp-button.test.ts
+++ b/tests/sp-button.test.ts
@@ -51,4 +51,13 @@ describe("SpButton behavior", () => {
 
     expect(html).toContain('tabindex="-1"');
   });
+
+  it("renders with id and aria-describedby", async () => {
+    const html = await container.renderToString(SpButton, {
+      props: { id: "submit-btn", "aria-describedby": "submit-desc" },
+    });
+
+    expect(html).toContain('id="submit-btn"');
+    expect(html).toContain('aria-describedby="submit-desc"');
+  });
 });


### PR DESCRIPTION
Identified a gap in the `SpButton` component where `id` and `aria-describedby` were not explicitly supported in the props interface, although they are critical for accessibility (e.g., when a button is described by external text).

Implemented the following changes:
1.  **`src/components/SpButton.astro`**: Added `id?: string` and `"aria-describedby"?: string` to `SpButtonProps`. Destructured these props and explicitly assigned them to the rendered HTML tag.
2.  **`tests/sp-button.test.ts`**: Added a new test case to verify that `id` and `aria-describedby` are correctly rendered when provided.
3.  **`package.json`**: Added `jiti` to `devDependencies` to fix an environment issue where `npm run lint` failed due to the TypeScript ESLint configuration requiring `jiti`.

All 116 tests passed, and `npm run check` (lint, build, typecheck, test) is green.

---
*PR created automatically by Jules for task [6728558138888111367](https://jules.google.com/task/6728558138888111367) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpButton component now accepts `id` and `aria-describedby` attributes for enhanced accessibility support.

* **Tests**
  * Added test coverage verifying the new attributes are properly rendered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->