### PR TITLE
Add missing id and aria-describedby to SpIconBox

### DIFF
--- a/src/components/SpIconBox.astro
+++ b/src/components/SpIconBox.astro
@@ -15,7 +15,9 @@ interface SpIconBoxProps extends IconBoxRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
   fullWidth?: boolean;
 
   [key: string]: unknown;
@@ -39,7 +41,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpIconBoxProps;
 
@@ -81,7 +85,9 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   aria-disabled={isIconBoxDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   tabindex={finalTabIndex}
+  id={id}
   {...rest}
 >
   <slot />

--- a/tests/sp-icon-box.test.ts
+++ b/tests/sp-icon-box.test.ts
@@ -97,4 +97,13 @@ describe("SpIconBox behavior", () => {
     expect(html).toContain("sp-iconbox--full");
     expect(html).not.toContain('fullWidth="true"');
   });
+
+  it("renders id and aria-describedby", async () => {
+    const html = await container.renderToString(SpIconBox, {
+      props: { id: "my-iconbox", "aria-describedby": "desc-id" },
+    });
+
+    expect(html).toContain('id="my-iconbox"');
+    expect(html).toContain('aria-describedby="desc-id"');
+  });
 });


### PR DESCRIPTION
Added missing `id` and `aria-describedby` support to `SpIconBox` component and added a regression test.

---
*PR created automatically by Jules for task [12548461271052326465](https://jules.google.com/task/12548461271052326465) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpIconBox component now supports id and aria-describedby attributes.

* **Tests**
  * Added test coverage for id and aria-describedby attribute rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->