### PR TITLE
Add id and aria-describedby support to SpRating

### DIFF
--- a/src/components/SpRating.astro
+++ b/src/components/SpRating.astro
@@ -35,7 +35,9 @@ interface SpRatingProps extends RatingRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 
   [key: string]: unknown;
 }
@@ -59,7 +61,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpRatingProps;
 
@@ -105,10 +109,12 @@ const stars = Array.from({ length: max }, (_, i) => i < value);
   aria-disabled={isRatingDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   aria-valuenow={value}
   aria-valuemin={0}
   aria-valuemax={max}
   tabindex={finalTabIndex}
+  id={id}
   {...rest}
 >
   <span class={starsClasses} aria-hidden="true">

--- a/tests/sp-rating.test.ts
+++ b/tests/sp-rating.test.ts
@@ -54,6 +54,15 @@ describe("SpRating accessibility", () => {
     expect(html).not.toContain('tabindex="-1"');
     expect(html).toContain("disabled");
   });
+
+  it("renders with id and aria-describedby", async () => {
+    const html = await container.renderToString(SpRating, {
+      props: { id: "rating-1", "aria-describedby": "rating-desc" },
+    });
+
+    expect(html).toContain('id="rating-1"');
+    expect(html).toContain('aria-describedby="rating-desc"');
+  });
 });
 
 describe("SpRating interactive behavior", () => {


### PR DESCRIPTION
Added `id` and `aria-describedby` props to `SpRating.astro` and implemented them on the root element. Added a corresponding regression test in `tests/sp-rating.test.ts`. Verified with `npm run check`.

---
*PR created automatically by Jules for task [8516383724858524621](https://jules.google.com/task/8516383724858524621) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility for the rating component with enhanced ARIA attribute support, enabling better integration with screen readers and assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->