### PR TITLE
Add explicit id and aria-describedby support to SpCard

### DIFF
--- a/src/components/SpCard.astro
+++ b/src/components/SpCard.astro
@@ -26,7 +26,9 @@ interface SpCardProps extends CardRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 
   loading?: boolean;
   hovered?: boolean;
@@ -53,7 +55,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpCardProps;
 
@@ -94,7 +98,9 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   aria-disabled={isCardDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   tabindex={finalTabIndex}
+  id={id}
   {...rest}
 >
   <slot />

--- a/tests/sp-card.test.ts
+++ b/tests/sp-card.test.ts
@@ -102,4 +102,13 @@ describe("SpCard accessibility and tabindex guarding", () => {
     const interactiveClasses = getCardClasses({ interactive: true });
     expect(html).toContain(interactiveClasses);
   });
+
+  it("renders id and aria-describedby", async () => {
+    const html = await container.renderToString(SpCard, {
+      props: { id: "my-card", "aria-describedby": "desc-id" },
+    });
+
+    expect(html).toContain('id="my-card"');
+    expect(html).toContain('aria-describedby="desc-id"');
+  });
 });


### PR DESCRIPTION
This change adds explicit support for the `id` and `aria-describedby` props to the `SpCard` component. This aligns the component with the established pattern in the adapter, improving type safety and ensuring these standard accessibility attributes are correctly applied to the root element across all polymorphic tags. Regression tests were added to verify the fix.

---
*PR created automatically by Jules for task [15820238169325762218](https://jules.google.com/task/15820238169325762218) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended SpCard component with support for optional `id` and `aria-describedby` properties, allowing more granular control over component attributes and rendering.

* **Tests**
  * Added test case verifying that the component correctly renders and applies the `id` and `aria-describedby` attributes when these properties are provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phcdevworks/spectre-ui-astro/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->