### PR TITLE
Add explicit id and aria-describedby support to SpBadge

### DIFF
--- a/src/components/SpBadge.astro
+++ b/src/components/SpBadge.astro
@@ -16,7 +16,9 @@ interface SpBadgeProps extends BadgeRecipeOptions {
   type?: "button" | "submit" | "reset";
   datetime?: string;
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 
   loading?: boolean;
 
@@ -41,7 +43,9 @@ const {
   type,
   datetime,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpBadgeProps;
 
@@ -82,8 +86,10 @@ const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   aria-disabled={isBadgeDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   datetime={Tag === "time" ? datetime : undefined}
   tabindex={finalTabIndex}
+  id={id}
   {...rest}
 >
   <slot />

--- a/tests/sp-badge.test.ts
+++ b/tests/sp-badge.test.ts
@@ -77,3 +77,34 @@ describe("SpBadge interactivity and tabindex guarding", () => {
     expect(html).toContain(interactiveClasses);
   });
 });
+
+describe("SpBadge explicit attribute support", () => {
+  it("renders id and aria-describedby when provided", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        id: "my-badge",
+        "aria-describedby": "description-id",
+      },
+    });
+
+    expect(html).toContain('id="my-badge"');
+    expect(html).toContain('aria-describedby="description-id"');
+  });
+
+  it("does not leak id or aria-describedby twice when provided", async () => {
+    const html = await container.renderToString(SpBadge, {
+      props: {
+        id: "my-badge",
+        "aria-describedby": "description-id",
+      },
+    });
+
+    // Check for single occurrence of id="my-badge"
+    const idMatches = html.match(/id="my-badge"/g);
+    expect(idMatches).toHaveLength(1);
+
+    // Check for single occurrence of aria-describedby="description-id"
+    const ariaMatches = html.match(/aria-describedby="description-id"/g);
+    expect(ariaMatches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Added explicit `id` and `aria-describedby` support to `SpBadge` component to improve accessibility ergonomics and TypeScript discoverability. Verified with unit tests and manual DOM inspection.

---
*PR created automatically by Jules for task [239424723454865978](https://jules.google.com/task/239424723454865978) started by @bradpotts*