### PR TITLE
Add id and aria-describedby support to SpPricingCard

### DIFF
--- a/src/components/SpPricingCard.astro
+++ b/src/components/SpPricingCard.astro
@@ -33,7 +33,9 @@ interface SpPricingCardProps extends PricingCardRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 
   [key: string]: unknown;
 }
@@ -54,7 +56,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpPricingCardProps;
 
@@ -99,7 +103,9 @@ const descriptionClasses = getPricingCardDescriptionClasses();
   aria-disabled={isPricingCardDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   tabindex={finalTabIndex}
+  id={id}
   {...rest}
 >
   <slot name="header" />

--- a/tests/sp-pricing-card.test.ts
+++ b/tests/sp-pricing-card.test.ts
@@ -84,6 +84,18 @@ describe("SpPricingCard behavior", () => {
     expect(html).not.toContain('fullHeight="true"');
   });
 
+  it("renders id and aria-describedby attributes when provided", async () => {
+    const html = await container.renderToString(SpPricingCard, {
+      props: {
+        id: "test-id",
+        "aria-describedby": "desc-id",
+      },
+    });
+
+    expect(html).toContain('id="test-id"');
+    expect(html).toContain('aria-describedby="desc-id"');
+  });
+
   describe("slot behavior", () => {
     it("does not render empty wrapper divs when slots are not provided", async () => {
       const html = await container.renderToString(SpPricingCard, {


### PR DESCRIPTION
This change addresses an accessibility gap in the `SpPricingCard` component by adding explicit support for `id` and `aria-describedby` attributes.

Changes:
- Updated `SpPricingCard.astro` to include `id` and `aria-describedby` in its props and apply them to the root element.
- Added a regression test in `tests/sp-pricing-card.test.ts` to ensure these attributes are correctly rendered.

Verification:
- `npm run check` passed successfully (lint, build, typecheck, tests).
- Verified that `id` and `aria-describedby` are correctly applied to the DOM.
- Confirmed no prop leakage or unintended side effects.

---
*PR created automatically by Jules for task [13012582046464989032](https://jules.google.com/task/13012582046464989032) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing card component now supports additional accessibility attributes for improved screen reader compatibility.

* **Tests**
  * Added test coverage to verify new accessibility attribute functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->