### PR TITLE
fix(spectre-ui-astro): add explicit id and aria-describedby support to SpTestimonial

### DIFF
--- a/src/components/SpTestimonial.astro
+++ b/src/components/SpTestimonial.astro
@@ -34,7 +34,9 @@ interface SpTestimonialProps extends TestimonialRecipeOptions {
 
   type?: "button" | "submit" | "reset";
   tabindex?: number;
+  id?: string;
   "aria-label"?: string;
+  "aria-describedby"?: string;
 
   [key: string]: unknown;
 }
@@ -55,7 +57,9 @@ const {
   rel,
   type,
   tabindex,
+  id,
   "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
   ...rest
 } = Astro.props as SpTestimonialProps;
 
@@ -96,11 +100,13 @@ const authorTitleClasses = getTestimonialAuthorTitleClasses();
   target={Tag === "a" ? target : undefined}
   rel={Tag === "a" ? rel : undefined}
   type={finalType}
+  id={id}
   disabled={Tag === "button" && isTestimonialDisabled ? true : undefined}
   role={isInteractive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-disabled={isTestimonialDisabled ? "true" : undefined}
   aria-busy={loading ? "true" : undefined}
   aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
   tabindex={finalTabIndex}
   {...rest}
 >

--- a/tests/sp-testimonial.test.ts
+++ b/tests/sp-testimonial.test.ts
@@ -25,6 +25,18 @@ describe("SpTestimonial SSR rendering", () => {
     expect(html).toContain('aria-label="User testimonial"');
   });
 
+  it("renders explicit id and aria-describedby", async () => {
+    const html = await container.renderToString(SpTestimonial, {
+      props: {
+        id: "testimonial-1",
+        "aria-describedby": "description-1",
+      },
+    });
+
+    expect(html).toContain('id="testimonial-1"');
+    expect(html).toContain('aria-describedby="description-1"');
+  });
+
   it("applies tabindex=-1 to a disabled anchor", async () => {
     const html = await container.renderToString(SpTestimonial, {
       props: { as: "a", href: "/testimonials/1", disabled: true },


### PR DESCRIPTION
This PR adds explicit support for `id` and `aria-describedby` attributes to the `SpTestimonial` component. These attributes were previously only available via the `...rest` spread, which could lead to attribute leakage if not handled carefully, and they were missing from the component's TypeScript interface. By explicitly implementing them, we ensure better accessibility, improved TypeScript discoverability, and consistency with other polymorphic components in the adapter (like `SpBadge`, `SpButton`, and `SpCard`).

Key changes:
- Updated `SpTestimonialProps` interface in `src/components/SpTestimonial.astro` to include `id` and `aria-describedby`.
- Destructured `id` and `aria-describedby` from `Astro.props` to prevent leakage into the `...rest` spread.
- Applied `id` and `aria-describedby` to the root element in the component template.
- Added a regression test in `tests/sp-testimonial.test.ts` to verify that these attributes are correctly rendered in the HTML.

---
*PR created automatically by Jules for task [12928650523957477981](https://jules.google.com/task/12928650523957477981) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Testimonial component now supports optional `id` and `aria-describedby` attributes, enabling improved accessibility and integration with other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->