### PR TITLE
Enhance SpAlert polymorphic support and accessibility parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ reflects package releases published to npm.
 
 ## [Unreleased]
 
+### Fixed
+
+- `SpAlert` now supports polymorphic rendering as `<a>` or `<button>` tags,
+  automatically infers its interactive state from the tag, and implements
+  proper accessibility guarding (role assignment and href suppression).
+
 ## [2.5.0] - 2026-06-03
 
 Release Title: Contract Hardening and Accessibility Parity

--- a/src/components/SpAlert.astro
+++ b/src/components/SpAlert.astro
@@ -3,7 +3,7 @@ import type { AlertRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getAlertClasses } from "@phcdevworks/spectre-ui";
 import { resolveInteractiveAttrs } from "./sp-interactive.shared";
 
-type SpAlertElement = "div" | "section" | "aside" | "article";
+type SpAlertElement = "div" | "section" | "aside" | "article" | "a" | "button";
 
 interface SpAlertProps extends AlertRecipeOptions {
   as?: SpAlertElement;
@@ -12,6 +12,12 @@ interface SpAlertProps extends AlertRecipeOptions {
   "aria-label"?: string;
   "aria-describedby"?: string;
   tabindex?: number;
+
+  href?: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+  type?: "button" | "submit" | "reset";
+
   [key: string]: unknown;
 }
 
@@ -32,36 +38,49 @@ const {
   "aria-label": ariaLabel,
   "aria-describedby": ariaDescribedby,
   tabindex,
+  href,
+  target,
+  rel,
+  type,
   ...rest
 } = Astro.props as SpAlertProps;
 
 const isAlertDisabled = disabled || loading;
+const isInteractive = interactive || Tag === "a" || Tag === "button";
 
 const classes = getAlertClasses({
   variant,
   size,
   dismissed,
   fullWidth,
-  interactive,
+  interactive: isInteractive,
+  disabled: isAlertDisabled,
+  loading,
   hovered,
   focused,
   active,
-  disabled: isAlertDisabled,
-  loading,
 });
 const finalClass = [classes, className].filter(Boolean).join(" ");
 
-const { finalTabIndex } = resolveInteractiveAttrs({
+const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
   Tag,
   isDisabled: isAlertDisabled,
-  interactive,
+  href,
+  type,
   tabindex,
+  interactive: isInteractive,
 });
 ---
 
 <Tag
   class={finalClass}
   id={id}
+  href={finalHref}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
+  disabled={Tag === "button" && isAlertDisabled ? true : undefined}
+  role={isInteractive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
   aria-label={ariaLabel}
   aria-describedby={ariaDescribedby}
   aria-disabled={isAlertDisabled ? "true" : undefined}

--- a/tests/sp-alert.test.ts
+++ b/tests/sp-alert.test.ts
@@ -102,6 +102,45 @@ describe("SpAlert interactivity and tabindex", () => {
     const html = await container.renderToString(SpAlert, { props: {} });
     expect(html).not.toContain("tabindex=");
   });
+
+  it("automatically infers interactive state when rendered as 'a' or 'button'", async () => {
+    const aHtml = await container.renderToString(SpAlert, { props: { as: "a", href: "#" } });
+    expect(aHtml).toContain("sp-alert--interactive");
+
+    const buttonHtml = await container.renderToString(SpAlert, { props: { as: "button" } });
+    expect(buttonHtml).toContain("sp-alert--interactive");
+  });
+
+  it("applies role='button' only to interactive non-native elements", async () => {
+    const divHtml = await container.renderToString(SpAlert, { props: { interactive: true } });
+    expect(divHtml).toContain('role="button"');
+
+    const buttonHtml = await container.renderToString(SpAlert, { props: { as: "button" } });
+    expect(buttonHtml).not.toContain('role="button"');
+
+    const aHtml = await container.renderToString(SpAlert, { props: { as: "a", href: "#" } });
+    expect(aHtml).not.toContain('role="button"');
+  });
+});
+
+describe("SpAlert polymorphic rendering", () => {
+  it("renders as 'a' with href and guards href when disabled", async () => {
+    const html = await container.renderToString(SpAlert, { props: { as: "a", href: "https://example.com" } });
+    expect(html).toContain('<a');
+    expect(html).toContain('href="https://example.com"');
+
+    const disabledHtml = await container.renderToString(SpAlert, { props: { as: "a", href: "https://example.com", disabled: true } });
+    expect(disabledHtml).not.toContain('href="https://example.com"');
+  });
+
+  it("renders as 'button' with type and handles disabled state", async () => {
+    const html = await container.renderToString(SpAlert, { props: { as: "button", type: "submit" } });
+    expect(html).toContain('<button');
+    expect(html).toContain('type="submit"');
+
+    const disabledHtml = await container.renderToString(SpAlert, { props: { as: "button", disabled: true } });
+    expect(disabledHtml).toContain('disabled');
+  });
 });
 
 describe("SpAlert element and slot rendering", () => {


### PR DESCRIPTION
This PR enhances the `SpAlert` component to support polymorphic rendering as links or buttons. It ensures that interactive states are correctly inferred and that accessibility attributes (role, href, disabled) are handled safely and consistently with other adapter components.

---
*PR created automatically by Jules for task [16153545991211454737](https://jules.google.com/task/16153545991211454737) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SpAlert now supports polymorphic rendering as links or buttons with automatic interactive state inference.
  * Added support for link attributes (href, target, rel) and form control attributes (type, disabled).

* **Bug Fixes**
  * Enhanced accessibility safeguards including automatic role assignment and attribute suppression for disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->