### PR TITLE
Implement SpAvatar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Astro-native components for the [Spectre UI](https://github.com/phcdevworks/spec
 
 ## What Astro developers get
 
-- **Eight ready-to-use Astro components** — badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, and testimonials
+- **Ten ready-to-use Astro components** — alerts, avatars, badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, and testimonials
 - **SSR-safe by default** — deterministic markup, no client-side JavaScript, stable accessibility wiring
 - **Thin wrapper pattern** — styling comes entirely from `@phcdevworks/spectre-ui`; this package adds Astro slots, typed props, and framework ergonomics
 - **Re-exported recipe helpers** — use the same class functions the components use, directly from your Astro frontmatter or TypeScript
@@ -261,6 +261,38 @@ When `label`, `helperText`, or `errorMessage` is present, an explicit `id` is **
 <SpAlert variant="warning" size="sm">Session expires soon.</SpAlert>
 <SpAlert variant="danger" dismissed>This alert has been dismissed.</SpAlert>
 <SpAlert variant="info" as="aside" aria-label="Info notice">Read the docs.</SpAlert>
+```
+
+---
+
+### SpAvatar
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `shape` | `AvatarShape` | `"circle"` | Shape: `"circle"` `"square"` |
+| `size` | `AvatarSize` | `"md"` | Size: `"xs"` `"sm"` `"md"` `"lg"` `"xl"` |
+| `as` | `"div" \| "span" \| "figure" \| "a" \| "button"` | `"div"` | Rendered element |
+| `interactive` | `boolean` | — | Adds hover/focus styles |
+| `disabled` | `boolean` | — | Disables the avatar |
+| `loading` | `boolean` | — | Loading state |
+| `fullWidth` | `boolean` | — | Stretches to full width |
+| `placeholder` | `boolean` | — | Applies placeholder styling |
+| `href` | `string` | — | URL when `as="a"` |
+| `aria-label` | `string` | — | Accessible label |
+| `class` | `string` | — | Additional CSS classes |
+
+```astro
+<SpAvatar size="lg">
+  <img src="/avatars/jane.jpg" alt="Jane Doe" />
+</SpAvatar>
+
+<SpAvatar shape="square" size="sm" placeholder>
+  JD
+</SpAvatar>
+
+<SpAvatar as="a" href="/profile" interactive>
+  <img src="/avatars/jane.jpg" alt="View profile" />
+</SpAvatar>
 ```
 
 ---
@@ -517,6 +549,8 @@ const links = [
 
 | Helper | For |
 |--------|-----|
+| `getAlertClasses` | Alert class generation |
+| `getAvatarClasses` | Avatar class generation |
 | `getButtonClasses` | Button class generation |
 | `getCardClasses` | Card class generation |
 | `getBadgeClasses` | Badge class generation |
@@ -538,7 +572,7 @@ const links = [
 | `getTestimonialAuthorNameClasses` | Author name element |
 | `getTestimonialAuthorTitleClasses` | Author title element |
 
-Recipe option and variant types are also re-exported: `BadgeRecipeOptions`, `BadgeVariant`, `BadgeSize`, `ButtonRecipeOptions`, `ButtonVariant`, `ButtonSize`, `CardRecipeOptions`, `CardVariant`, `IconBoxRecipeOptions`, `IconBoxVariant`, `IconBoxSize`, `InputRecipeOptions`, `InputState`, `InputSize`, `PricingCardRecipeOptions`, `RatingRecipeOptions`, `TestimonialRecipeOptions`.
+Recipe option and variant types are also re-exported: `AlertRecipeOptions`, `AlertVariant`, `AlertSize`, `AvatarRecipeOptions`, `AvatarShape`, `AvatarSize`, `BadgeRecipeOptions`, `BadgeVariant`, `BadgeSize`, `ButtonRecipeOptions`, `ButtonVariant`, `ButtonSize`, `CardRecipeOptions`, `CardVariant`, `IconBoxRecipeOptions`, `IconBoxVariant`, `IconBoxSize`, `InputRecipeOptions`, `InputState`, `InputSize`, `PricingCardRecipeOptions`, `RatingRecipeOptions`, `TestimonialRecipeOptions`.
 
 ## What this package owns
 
@@ -587,7 +621,7 @@ Do not use this package when:
 
 ```ts
 import {
-  SpBadge, SpButton, SpCard, SpIconBox, SpInput,
+  SpAlert, SpAvatar, SpBadge, SpButton, SpCard, SpIconBox, SpInput,
   SpPricingCard, SpRating, SpTestimonial,
 } from '@phcdevworks/spectre-ui-astro'
 
@@ -602,6 +636,8 @@ import {
 ### Direct component entry points
 
 ```ts
+import SpAlert     from '@phcdevworks/spectre-ui-astro/components/SpAlert.astro'
+import SpAvatar    from '@phcdevworks/spectre-ui-astro/components/SpAvatar.astro'
 import SpBadge     from '@phcdevworks/spectre-ui-astro/components/SpBadge.astro'
 import SpButton    from '@phcdevworks/spectre-ui-astro/components/SpButton.astro'
 import SpCard      from '@phcdevworks/spectre-ui-astro/components/SpCard.astro'
@@ -621,6 +657,7 @@ Each component family is classified by its support status in this adapter.
 | Family | Status | Notes |
 |--------|--------|-------|
 | alert | **stable** | Full prop, slot, ARIA, and SSR coverage |
+| avatar | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | badge | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | button | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | card | **stable** | Full prop, slot, ARIA, and SSR coverage |
@@ -629,7 +666,6 @@ Each component family is classified by its support status in this adapter.
 | pricing-card | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | rating | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | testimonial | **stable** | Full prop, slot, ARIA, and SSR coverage |
-| avatar | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 | spinner | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 | tag | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 

--- a/astro-adapter.contract.json
+++ b/astro-adapter.contract.json
@@ -3,6 +3,7 @@
   "rootExports": {
     "components": [
       "SpAlert",
+      "SpAvatar",
       "SpBadge",
       "SpButton",
       "SpCard",
@@ -81,6 +82,7 @@
   },
   "componentEntrypoints": [
     "./components/SpAlert.astro",
+    "./components/SpAvatar.astro",
     "./components/SpBadge.astro",
     "./components/SpButton.astro",
     "./components/SpCard.astro",
@@ -117,6 +119,7 @@
   "componentFamilies": {
     "stable": [
       "alert",
+      "avatar",
       "badge",
       "button",
       "card",
@@ -127,6 +130,6 @@
       "testimonial"
     ],
     "provisional": [],
-    "notYetSupported": ["avatar", "spinner", "tag"]
+    "notYetSupported": ["spinner", "tag"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "peerDependencies": {
         "@phcdevworks/spectre-tokens": "^2.6.0",
-        "@phcdevworks/spectre-ui": "^1.5.0",
+        "@phcdevworks/spectre-ui": "^1.7.0",
         "astro": "^6.1.3",
         "typescript": "^5.9 || ^6.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "default": "./dist/index.js"
     },
     "./components/SpAlert.astro": "./dist/components/SpAlert.astro",
+    "./components/SpAvatar.astro": "./dist/components/SpAvatar.astro",
     "./components/SpBadge.astro": "./dist/components/SpBadge.astro",
     "./components/SpButton.astro": "./dist/components/SpButton.astro",
     "./components/SpCard.astro": "./dist/components/SpCard.astro",

--- a/src/components/SpAvatar.astro
+++ b/src/components/SpAvatar.astro
@@ -1,0 +1,93 @@
+---
+import type { AvatarRecipeOptions } from "@phcdevworks/spectre-ui";
+import { getAvatarClasses } from "@phcdevworks/spectre-ui";
+import { resolveInteractiveAttrs } from "./sp-interactive.shared";
+
+type SpAvatarElement = "div" | "span" | "figure" | "a" | "button";
+
+interface SpAvatarProps extends AvatarRecipeOptions {
+  as?: SpAvatarElement;
+  class?: string;
+
+  href?: string;
+  target?: "_blank" | "_self" | "_parent" | "_top";
+  rel?: string;
+
+  type?: "button" | "submit" | "reset";
+  tabindex?: number;
+  id?: string;
+  "aria-label"?: string;
+  "aria-describedby"?: string;
+
+  [key: string]: unknown;
+}
+
+const {
+  shape,
+  size,
+  interactive,
+  disabled,
+  loading,
+  hovered,
+  focused,
+  active,
+  fullWidth,
+  placeholder,
+  as: Tag = "div",
+  class: className,
+  href,
+  target,
+  rel,
+  type,
+  tabindex,
+  id,
+  "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedby,
+  ...rest
+} = Astro.props as SpAvatarProps;
+
+const isAvatarDisabled = disabled || loading;
+const isInteractive = interactive || Tag === "a" || Tag === "button";
+
+const classes = getAvatarClasses({
+  shape,
+  size,
+  interactive: isInteractive,
+  disabled: isAvatarDisabled,
+  loading,
+  hovered,
+  focused,
+  active,
+  fullWidth,
+  placeholder,
+});
+const finalClass = [classes, className].filter(Boolean).join(" ");
+
+const { finalType, finalHref, finalTabIndex } = resolveInteractiveAttrs({
+  Tag,
+  isDisabled: isAvatarDisabled,
+  href,
+  type,
+  tabindex,
+  interactive: isInteractive,
+});
+---
+
+<Tag
+  class={finalClass}
+  href={finalHref}
+  target={Tag === "a" ? target : undefined}
+  rel={Tag === "a" ? rel : undefined}
+  type={finalType}
+  disabled={Tag === "button" && isAvatarDisabled ? true : undefined}
+  role={isInteractive && Tag !== "button" && Tag !== "a" ? "button" : undefined}
+  aria-disabled={isAvatarDisabled ? "true" : undefined}
+  aria-busy={loading ? "true" : undefined}
+  aria-label={ariaLabel}
+  aria-describedby={ariaDescribedby}
+  tabindex={finalTabIndex}
+  id={id}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Components (Astro)
 export { default as SpAlert } from "./components/SpAlert.astro";
+export { default as SpAvatar } from "./components/SpAvatar.astro";
 export { default as SpBadge } from "./components/SpBadge.astro";
 export { default as SpButton } from "./components/SpButton.astro";
 export { default as SpCard } from "./components/SpCard.astro";

--- a/tests/sp-avatar.test.ts
+++ b/tests/sp-avatar.test.ts
@@ -1,0 +1,89 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpAvatar from "../src/components/SpAvatar.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpAvatar class and prop behavior", () => {
+  it("applies focused state and does not leak the prop to DOM", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { focused: true },
+    });
+
+    expect(html).toContain("sp-avatar--focus");
+    expect(html).not.toContain('focused="true"');
+  });
+
+  it("applies loading state and sets aria-busy", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { loading: true },
+    });
+
+    expect(html).toContain("sp-avatar--loading");
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("applies fullWidth and placeholder classes", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { fullWidth: true, placeholder: true },
+    });
+
+    expect(html).toContain("sp-avatar--full");
+    expect(html).toContain("sp-avatar--placeholder");
+  });
+});
+
+describe("SpAvatar polymorphic rendering", () => {
+  it("renders as a button when as='button'", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { as: "button" },
+    });
+
+    expect(html).toContain("<button");
+    expect(html).toContain('sp-avatar--interactive');
+  });
+
+  it("renders as an anchor with href", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { as: "a", href: "/profile" },
+    });
+
+    expect(html).toContain("<a");
+    expect(html).toContain('href="/profile"');
+    expect(html).toContain('sp-avatar--interactive');
+  });
+
+  it("guards tabindex=0 for non-native interactive elements", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { as: "div", interactive: true },
+    });
+
+    expect(html).toContain('tabindex="0"');
+    expect(html).toContain('role="button"');
+  });
+
+  it("suppresses href and sets tabindex=-1 when disabled", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { as: "a", href: "/profile", disabled: true },
+    });
+
+    expect(html).not.toContain('href="/profile"');
+    expect(html).toContain('tabindex="-1"');
+    expect(html).toContain('aria-disabled="true"');
+  });
+});
+
+describe("SpAvatar explicit attribute support", () => {
+  it("renders id and aria-describedby", async () => {
+    const html = await container.renderToString(SpAvatar, {
+      props: { id: "my-avatar", "aria-describedby": "desc" },
+    });
+
+    expect(html).toContain('id="my-avatar"');
+    expect(html).toContain('aria-describedby="desc"');
+  });
+});


### PR DESCRIPTION
Implemented the missing `SpAvatar` component, which was previously listed as "not yet supported." The implementation follows the established adapter pattern: thin, SSR-safe, accessible, and faithful to the upstream `@phcdevworks/spectre-ui` contracts. Included full unit test coverage and updated documentation.

---
*PR created automatically by Jules for task [6427124893435030099](https://jules.google.com/task/6427124893435030099) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar component is now available and marked as stable for production use.

* **Documentation**
  * Updated documentation with Avatar component usage examples, import paths, and available configuration options.

* **Package Updates**
  * Added Avatar component to root-level and direct component entry point exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->