### PR TITLE
Add SpSpinner component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Astro-native components for the [Spectre UI](https://github.com/phcdevworks/spec
 
 ## What Astro developers get
 
-- **Ten ready-to-use Astro components** — alerts, avatars, badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, and testimonials
+- **Eleven ready-to-use Astro components** — alerts, avatars, badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, spinners, and testimonials
 - **SSR-safe by default** — deterministic markup, no client-side JavaScript, stable accessibility wiring
 - **Thin wrapper pattern** — styling comes entirely from `@phcdevworks/spectre-ui`; this package adds Astro slots, typed props, and framework ergonomics
 - **Re-exported recipe helpers** — use the same class functions the components use, directly from your Astro frontmatter or TypeScript
@@ -72,6 +72,7 @@ import {
   SpIconBox,
   SpInput,
   SpPricingCard,
+  SpSpinner,
 } from '@phcdevworks/spectre-ui-astro'
 ---
 
@@ -439,6 +440,22 @@ Renders a star rating. Stars are built from `value`/`max`. Provide a custom star
 
 ---
 
+### SpSpinner
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `SpinnerSize` | — | Size: `"sm"` `"md"` `"lg"` |
+| `as` | `"div" \| "span" \| "i"` | `"div"` | Rendered element |
+| `aria-label` | `string` | — | Accessible label for the loading state |
+| `class` | `string` | — | Additional CSS classes |
+
+```astro
+<SpSpinner size="lg" aria-label="Loading..." />
+<SpSpinner as="span" />
+```
+
+---
+
 ### SpTestimonial
 
 Named slots map to the structural sections of the testimonial. Slot wrappers render only when their slot is populated.
@@ -622,7 +639,7 @@ Do not use this package when:
 ```ts
 import {
   SpAlert, SpAvatar, SpBadge, SpButton, SpCard, SpIconBox, SpInput,
-  SpPricingCard, SpRating, SpTestimonial,
+  SpPricingCard, SpRating, SpSpinner, SpTestimonial,
 } from '@phcdevworks/spectre-ui-astro'
 
 import {
@@ -645,6 +662,7 @@ import SpIconBox   from '@phcdevworks/spectre-ui-astro/components/SpIconBox.astr
 import SpInput     from '@phcdevworks/spectre-ui-astro/components/SpInput.astro'
 import SpPricingCard  from '@phcdevworks/spectre-ui-astro/components/SpPricingCard.astro'
 import SpRating    from '@phcdevworks/spectre-ui-astro/components/SpRating.astro'
+import SpSpinner   from '@phcdevworks/spectre-ui-astro/components/SpSpinner.astro'
 import SpTestimonial from '@phcdevworks/spectre-ui-astro/components/SpTestimonial.astro'
 ```
 
@@ -665,8 +683,8 @@ Each component family is classified by its support status in this adapter.
 | input | **stable** | Full prop, ARIA, SSR, and explicit `id` invariant coverage |
 | pricing-card | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | rating | **stable** | Full prop, slot, ARIA, and SSR coverage |
+| spinner | **stable** | Full prop, ARIA, and SSR coverage |
 | testimonial | **stable** | Full prop, slot, ARIA, and SSR coverage |
-| spinner | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 | tag | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 
 **stable** — the component family is fully wired to upstream recipes, covered by SSR and unit tests, and declared in `astro-adapter.contract.json`. Breaking changes require a semver major bump.

--- a/astro-adapter.contract.json
+++ b/astro-adapter.contract.json
@@ -11,6 +11,7 @@
       "SpInput",
       "SpPricingCard",
       "SpRating",
+      "SpSpinner",
       "SpTestimonial"
     ],
     "recipeHelpers": [
@@ -90,6 +91,7 @@
     "./components/SpInput.astro",
     "./components/SpPricingCard.astro",
     "./components/SpRating.astro",
+    "./components/SpSpinner.astro",
     "./components/SpTestimonial.astro"
   ],
   "peerDependencies": {
@@ -127,9 +129,10 @@
       "input",
       "pricing-card",
       "rating",
+      "spinner",
       "testimonial"
     ],
     "provisional": [],
-    "notYetSupported": ["spinner", "tag"]
+    "notYetSupported": ["tag"]
   }
 }

--- a/examples/src/pages/primitives.astro
+++ b/examples/src/pages/primitives.astro
@@ -3,6 +3,7 @@ import {
   SpBadge,
   SpCard,
   SpIconBox,
+  SpSpinner,
   getButtonClasses,
 } from "@phcdevworks/spectre-ui-astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -94,6 +95,15 @@ import BaseLayout from "../layouts/BaseLayout.astro";
               <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
             </svg>
           </SpIconBox>
+        </div>
+      </SpCard>
+
+      <SpCard variant="flat" class="sp-stack">
+        <h2>Spinner Sizes</h2>
+        <div class="sp-hstack inline">
+          <SpSpinner size="sm" aria-label="Small spinner" />
+          <SpSpinner size="md" aria-label="Medium spinner" />
+          <SpSpinner size="lg" aria-label="Large spinner" />
         </div>
       </SpCard>
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "./components/SpInput.astro": "./dist/components/SpInput.astro",
     "./components/SpPricingCard.astro": "./dist/components/SpPricingCard.astro",
     "./components/SpRating.astro": "./dist/components/SpRating.astro",
+    "./components/SpSpinner.astro": "./dist/components/SpSpinner.astro",
     "./components/SpTestimonial.astro": "./dist/components/SpTestimonial.astro"
   },
   "files": [

--- a/src/components/SpSpinner.astro
+++ b/src/components/SpSpinner.astro
@@ -1,0 +1,38 @@
+---
+import type { SpinnerRecipeOptions } from "@phcdevworks/spectre-ui";
+import { getSpinnerClasses } from "@phcdevworks/spectre-ui";
+
+type SpSpinnerElement = "div" | "span" | "i";
+
+interface SpSpinnerProps extends SpinnerRecipeOptions {
+  as?: SpSpinnerElement;
+  class?: string;
+  id?: string;
+  "aria-label"?: string;
+  [key: string]: unknown;
+}
+
+const {
+  size,
+  as: Tag = "div",
+  class: className,
+  id,
+  "aria-label": ariaLabel,
+  ...rest
+} = Astro.props as SpSpinnerProps;
+
+const classes = getSpinnerClasses({
+  size,
+});
+const finalClass = [classes, className].filter(Boolean).join(" ");
+---
+
+<Tag
+  class={finalClass}
+  id={id}
+  role="status"
+  aria-label={ariaLabel}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as SpIconBox } from "./components/SpIconBox.astro";
 export { default as SpInput } from "./components/SpInput.astro";
 export { default as SpPricingCard } from "./components/SpPricingCard.astro";
 export { default as SpRating } from "./components/SpRating.astro";
+export { default as SpSpinner } from "./components/SpSpinner.astro";
 export { default as SpTestimonial } from "./components/SpTestimonial.astro";
 
 // Re-export all types and recipes

--- a/tests/sp-spinner.test.ts
+++ b/tests/sp-spinner.test.ts
@@ -1,0 +1,60 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { beforeAll, describe, expect, it } from "vitest";
+import SpSpinner from "../src/components/SpSpinner.astro";
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+  container = await AstroContainer.create();
+});
+
+describe("SpSpinner rendering", () => {
+  it("renders a div with sp-spinner class by default", async () => {
+    const html = await container.renderToString(SpSpinner);
+    expect(html).toContain("<div");
+    expect(html).toContain("sp-spinner");
+    expect(html).toContain('role="status"');
+  });
+
+  it("renders as different tags via the 'as' prop", async () => {
+    const htmlSpan = await container.renderToString(SpSpinner, {
+      props: { as: "span" },
+    });
+    expect(htmlSpan).toContain("<span");
+
+    const htmlI = await container.renderToString(SpSpinner, {
+      props: { as: "i" },
+    });
+    expect(htmlI).toContain("<i");
+  });
+
+  it("applies size classes", async () => {
+    const html = await container.renderToString(SpSpinner, {
+      props: { size: "lg" },
+    });
+    expect(html).toContain("sp-spinner--lg");
+  });
+
+  it("passes through standard attributes", async () => {
+    const html = await container.renderToString(SpSpinner, {
+      props: { id: "my-spinner", "aria-label": "Loading results", "data-testid": "spinner" },
+    });
+    expect(html).toContain('id="my-spinner"');
+    expect(html).toContain('aria-label="Loading results"');
+    expect(html).toContain('data-testid="spinner"');
+  });
+
+  it("renders slot content", async () => {
+    const html = await container.renderToString(SpSpinner, {
+      slots: { default: "Loading..." },
+    });
+    expect(html).toContain("Loading...");
+  });
+
+  it("does not leak adapter props to the DOM", async () => {
+    const html = await container.renderToString(SpSpinner, {
+      props: { size: "sm" },
+    });
+    expect(html).not.toContain('size="');
+  });
+});


### PR DESCRIPTION
This PR adds the missing `SpSpinner` component to the Astro adapter, fulfilling the Phase 3 roadmap requirement. 

Key changes:
- Created `src/components/SpSpinner.astro` using the upstream `getSpinnerClasses` recipe.
- Added support for polymorphic rendering (`as` prop) and standard HTML attribute passthrough.
- Updated `src/index.ts` and `package.json` to export the new component.
- Updated `astro-adapter.contract.json` to mark `spinner` as stable.
- Added comprehensive unit and SSR tests in `tests/sp-spinner.test.ts`.
- Updated `README.md` with documentation and usage examples.
- Added `SpSpinner` to the `primitives.astro` example page for visual verification.

The component is SSR-safe, accessible (default `role="status"`), and follows the repository's established patterns for thin adapters.

---
*PR created automatically by Jules for task [11295052658137286857](https://jules.google.com/task/11295052658137286857) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `SpSpinner` component for displaying loading indicators with customizable sizing.
  * Spinner component family now marked as stable.

* **Documentation**
  * Added `SpSpinner` component documentation and usage examples.

* **Tests**
  * Added test suite for `SpSpinner`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->