### PR TITLE
Add SpSpinner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ reflects package releases published to npm.
 
 ### Added
 
+- Added `SpSpinner` component, providing an Astro wrapper for the upstream
+  `getSpinnerClasses` recipe with polymorphic rendering and SSR-safe
+  accessibility.
 - Added `@phcdevworks/spectre-manifest` as a devDependency. `spectre.manifest.json`
   at the repo root declares this package's ecosystem role, layer, exports, and
   allowed dependency targets. `check:ecosystem` validates it in the check pipeline.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Astro-native components for the [Spectre UI](https://github.com/phcdevworks/spec
 
 ## What Astro developers get
 
-- **Ten ready-to-use Astro components** — alerts, avatars, badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, and testimonials
+- **Eleven ready-to-use Astro components** — alerts, avatars, badges, buttons, cards, icon boxes, inputs, pricing cards, ratings, spinners, and testimonials
 - **SSR-safe by default** — deterministic markup, no client-side JavaScript, stable accessibility wiring
 - **Thin wrapper pattern** — styling comes entirely from `@phcdevworks/spectre-ui`; this package adds Astro slots, typed props, and framework ergonomics
 - **Re-exported recipe helpers** — use the same class functions the components use, directly from your Astro frontmatter or TypeScript
@@ -72,6 +72,7 @@ import {
   SpIconBox,
   SpInput,
   SpPricingCard,
+  SpSpinner,
 } from '@phcdevworks/spectre-ui-astro'
 ---
 
@@ -103,6 +104,8 @@ import {
     <span slot="description">For growing teams.</span>
     <SpButton variant="primary" fullWidth>Choose plan</SpButton>
   </SpPricingCard>
+
+  <SpSpinner size="md" aria-label="Loading..." />
 </BaseLayout>
 ```
 
@@ -478,6 +481,23 @@ Named slots map to the structural sections of the testimonial. Slot wrappers ren
 
 ---
 
+### SpSpinner
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `size` | `SpinnerSize` | — | Size: `"sm"` `"md"` `"lg"` |
+| `as` | `"div" \| "span" \| "i"` | `"div"` | Rendered element |
+| `id` | `string` | — | Element ID |
+| `aria-label` | `string` | — | Accessible label for the loading state |
+| `class` | `string` | — | Additional CSS classes |
+
+```astro
+<SpSpinner size="md" aria-label="Loading..." />
+<SpSpinner size="lg" as="span" class="custom-spinner" />
+```
+
+---
+
 ## Polymorphic rendering (`as` prop)
 
 Most components accept an `as` prop to change the rendered HTML element without changing component behavior or styling.
@@ -622,7 +642,7 @@ Do not use this package when:
 ```ts
 import {
   SpAlert, SpAvatar, SpBadge, SpButton, SpCard, SpIconBox, SpInput,
-  SpPricingCard, SpRating, SpTestimonial,
+  SpPricingCard, SpRating, SpSpinner, SpTestimonial,
 } from '@phcdevworks/spectre-ui-astro'
 
 import {
@@ -645,6 +665,7 @@ import SpIconBox   from '@phcdevworks/spectre-ui-astro/components/SpIconBox.astr
 import SpInput     from '@phcdevworks/spectre-ui-astro/components/SpInput.astro'
 import SpPricingCard  from '@phcdevworks/spectre-ui-astro/components/SpPricingCard.astro'
 import SpRating    from '@phcdevworks/spectre-ui-astro/components/SpRating.astro'
+import SpSpinner   from '@phcdevworks/spectre-ui-astro/components/SpSpinner.astro'
 import SpTestimonial from '@phcdevworks/spectre-ui-astro/components/SpTestimonial.astro'
 ```
 
@@ -665,8 +686,8 @@ Each component family is classified by its support status in this adapter.
 | input | **stable** | Full prop, ARIA, SSR, and explicit `id` invariant coverage |
 | pricing-card | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | rating | **stable** | Full prop, slot, ARIA, and SSR coverage |
+| spinner | **stable** | Full prop, slot, ARIA, and SSR coverage |
 | testimonial | **stable** | Full prop, slot, ARIA, and SSR coverage |
-| spinner | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 | tag | **not yet supported** | Upstream recipe available in `@phcdevworks/spectre-ui` ^1.7.0; Astro adapter planned |
 
 **stable** — the component family is fully wired to upstream recipes, covered by SSR and unit tests, and declared in `astro-adapter.contract.json`. Breaking changes require a semver major bump.

--- a/astro-adapter.contract.json
+++ b/astro-adapter.contract.json
@@ -11,6 +11,7 @@
       "SpInput",
       "SpPricingCard",
       "SpRating",
+      "SpSpinner",
       "SpTestimonial"
     ],
     "recipeHelpers": [
@@ -90,6 +91,7 @@
     "./components/SpInput.astro",
     "./components/SpPricingCard.astro",
     "./components/SpRating.astro",
+    "./components/SpSpinner.astro",
     "./components/SpTestimonial.astro"
   ],
   "peerDependencies": {
@@ -127,9 +129,10 @@
       "input",
       "pricing-card",
       "rating",
+      "spinner",
       "testimonial"
     ],
     "provisional": [],
-    "notYetSupported": ["spinner", "tag"]
+    "notYetSupported": ["tag"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "./components/SpInput.astro": "./dist/components/SpInput.astro",
     "./components/SpPricingCard.astro": "./dist/components/SpPricingCard.astro",
     "./components/SpRating.astro": "./dist/components/SpRating.astro",
+    "./components/SpSpinner.astro": "./dist/components/SpSpinner.astro",
     "./components/SpTestimonial.astro": "./dist/components/SpTestimonial.astro"
   },
   "files": [

--- a/src/components/SpSpinner.astro
+++ b/src/components/SpSpinner.astro
@@ -1,0 +1,38 @@
+---
+import type { SpinnerRecipeOptions } from "@phcdevworks/spectre-ui";
+import { getSpinnerClasses } from "@phcdevworks/spectre-ui";
+
+type SpSpinnerElement = "div" | "span" | "i";
+
+interface SpSpinnerProps extends SpinnerRecipeOptions {
+  as?: SpSpinnerElement;
+  class?: string;
+  id?: string;
+  "aria-label"?: string;
+  [key: string]: unknown;
+}
+
+const {
+  size,
+  as: Tag = "div",
+  class: className,
+  id,
+  "aria-label": ariaLabel,
+  ...rest
+} = Astro.props as SpSpinnerProps;
+
+const classes = getSpinnerClasses({
+  size,
+});
+const finalClass = [classes, className].filter(Boolean).join(" ");
+---
+
+<Tag
+  class={finalClass}
+  id={id}
+  role="status"
+  aria-label={ariaLabel}
+  {...rest}
+>
+  <slot />
+</Tag>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as SpIconBox } from "./components/SpIconBox.astro";
 export { default as SpInput } from "./components/SpInput.astro";
 export { default as SpPricingCard } from "./components/SpPricingCard.astro";
 export { default as SpRating } from "./components/SpRating.astro";
+export { default as SpSpinner } from "./components/SpSpinner.astro";
 export { default as SpTestimonial } from "./components/SpTestimonial.astro";
 
 // Re-export all types and recipes

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -19,6 +19,7 @@ import {
   getRatingStarClasses,
   getRatingStarsClasses,
   getRatingTextClasses,
+  getSpinnerClasses,
 } from "@phcdevworks/spectre-ui";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -30,6 +31,7 @@ import SpIconBox from "../src/components/SpIconBox.astro";
 import SpInput from "../src/components/SpInput.astro";
 import SpPricingCard from "../src/components/SpPricingCard.astro";
 import SpRating from "../src/components/SpRating.astro";
+import SpSpinner from "../src/components/SpSpinner.astro";
 import type { SpInputProps } from "../src/components/sp-input.shared";
 
 let container: AstroContainer;
@@ -295,5 +297,15 @@ describe("SSR rendering", () => {
     expect(html).toContain('aria-busy="true"');
     expect(html).toContain('aria-disabled="true"');
     expect(html).not.toContain('loading="true"');
+  });
+
+  it("renders SpSpinner with upstream classes and role='status'", async () => {
+    const html = await container.renderToString(SpSpinner, {
+      props: { size: "lg", as: "span" },
+    });
+
+    expect(html).toContain(getSpinnerClasses({ size: "lg" }));
+    expect(html).toContain('role="status"');
+    expect(html).toContain("<span");
   });
 });

--- a/tests/sp-spinner.test.ts
+++ b/tests/sp-spinner.test.ts
@@ -1,0 +1,80 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+import { SpSpinner } from "../src/index";
+
+describe("SpSpinner", () => {
+  it("renders with default classes and role", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner);
+
+    expect(result).toContain('class="sp-spinner');
+    expect(result).toContain('role="status"');
+    expect(result).toContain("<div");
+  });
+
+  it("renders as a different element using the 'as' prop", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { as: "span" },
+    });
+
+    expect(result).toContain("<span");
+    expect(result).toContain('class="sp-spinner');
+  });
+
+  it("applies size classes", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { size: "lg" },
+    });
+
+    expect(result).toContain('class="sp-spinner sp-spinner--lg"');
+  });
+
+  it("passes through additional classes", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { class: "custom-class" },
+    });
+
+    expect(result).toContain('class="sp-spinner');
+    expect(result).toContain("custom-class");
+  });
+
+  it("renders an explicit id", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { id: "my-spinner" },
+    });
+
+    expect(result).toContain('id="my-spinner"');
+  });
+
+  it("renders an aria-label", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { "aria-label": "Loading content" },
+    });
+
+    expect(result).toContain('aria-label="Loading content"');
+  });
+
+  it("does not leak adapter-only props to the DOM", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      props: { size: "md", as: "div" },
+    });
+
+    expect(result).not.toContain('size="md"');
+    expect(result).not.toContain('as="div"');
+  });
+
+  it("renders slot content", async () => {
+    const container = await AstroContainer.create();
+    const result = await container.renderToString(SpSpinner, {
+      slots: { default: "Loading..." },
+    });
+
+    expect(result).toContain("Loading...");
+  });
+});


### PR DESCRIPTION
Add the SpSpinner component to the Astro adapter, providing a thin wrapper over the upstream `@phcdevworks/spectre-ui` spinner recipe. This includes support for polymorphic rendering, accessibility best practices, and full integration with the adapter's contract and documentation.

---
*PR created automatically by Jules for task [15561382219380417601](https://jules.google.com/task/15561382219380417601) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `SpSpinner`, a new accessible spinner component with polymorphic rendering support and SSR-safe accessibility. The spinner component family is now stable.

* **Documentation**
  * Updated README with component documentation, configuration options, and usage examples.

* **Tests**
  * Added comprehensive test coverage for the new spinner component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->