### PR TITLE
Add polymorphic rendering support to SpSpinner

### DIFF
--- a/src/components/SpSpinner.astro
+++ b/src/components/SpSpinner.astro
@@ -2,7 +2,10 @@
 import type { SpinnerRecipeOptions } from "@phcdevworks/spectre-ui";
 import { getSpinnerClasses } from "@phcdevworks/spectre-ui";
 
+type SpSpinnerElement = "div" | "span" | "i";
+
 interface SpSpinnerProps extends SpinnerRecipeOptions {
+  as?: SpSpinnerElement;
   class?: string;
   id?: string;
   "aria-label"?: string;
@@ -14,6 +17,7 @@ const {
   size,
   disabled,
   loading,
+  as: Tag = "div",
   class: className,
   id,
   "aria-label": ariaLabel,
@@ -26,7 +30,7 @@ const classes = getSpinnerClasses({ variant, size, disabled: isDisabled, loading
 const finalClass = [classes, className].filter(Boolean).join(" ");
 ---
 
-<div
+<Tag
   class={finalClass}
   id={id}
   role="status"
@@ -36,4 +40,4 @@ const finalClass = [classes, className].filter(Boolean).join(" ");
   {...rest}
 >
   <slot />
-</div>
+</Tag>

--- a/tests/sp-spinner.test.ts
+++ b/tests/sp-spinner.test.ts
@@ -87,9 +87,17 @@ describe("SpSpinner ARIA and accessibility", () => {
 });
 
 describe("SpSpinner element and slot rendering", () => {
-  it("renders as div", async () => {
+  it("renders as div by default", async () => {
     const html = await container.renderToString(SpSpinner, { props: {} });
     expect(html).toContain("<div");
+  });
+
+  it("renders as the specified element without leaking 'as'", async () => {
+    for (const as of ["div", "span", "i"] as const) {
+      const html = await container.renderToString(SpSpinner, { props: { as } });
+      expect(html).toContain(`<${as}`);
+      expect(html).not.toContain(`as="${as}"`);
+    }
   });
 
   it("renders slot content", async () => {


### PR DESCRIPTION
I identified a gap in the `SpSpinner` component, which was missing the standard polymorphic rendering support (`as` prop) present in other adapter components. I have implemented this support, allowing `SpSpinner` to render as a `div`, `span`, or `i` element. I also added comprehensive tests to verify this behavior and ensure that the `as` prop does not leak to the rendered HTML. All validation steps (`build`, `typecheck`, `test`) have passed.

---
*PR created automatically by Jules for task [10284074208503321997](https://jules.google.com/task/10284074208503321997) started by @bradpotts*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SpSpinner now supports polymorphic rendering via an optional `as` prop, enabling you to customize the underlying HTML element. Select from `div`, `span`, or `i` elements while preserving all existing spinner functionality, styling, and accessibility features. The component defaults to rendering as a `div` to maintain backward compatibility with existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->